### PR TITLE
Translate admin interface to English

### DIFF
--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -31,8 +31,8 @@ export function AdminDashboard() {
 
   const stats = [
     { label: "Clients", value: clients.length, icon: Building2 },
-    { label: "Utilisateurs", value: users.length, icon: Users },
-    { label: "Projets", value: projects.length, icon: ClipboardList },
+    { label: "Users", value: users.length, icon: Users },
+    { label: "Projects", value: projects.length, icon: ClipboardList },
     { label: "ASK", value: asks.length, icon: MessageSquare }
   ];
 
@@ -49,7 +49,7 @@ export function AdminDashboard() {
               <h1 className="text-2xl font-bold bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent">
                 Backoffice Agentic Design Flow
               </h1>
-              <p className="text-sm text-muted-foreground">Gestion centralisée des clients, projets, challenges et sessions ASK</p>
+              <p className="text-sm text-muted-foreground">Centralized management of clients, projects, challenges, and ASK sessions</p>
             </div>
           </div>
         </div>
@@ -67,7 +67,7 @@ export function AdminDashboard() {
               onClick={() => setFeedback(null)}
               className="text-xs text-muted-foreground underline"
             >
-              Fermer
+              Close
             </button>
           </Alert>
         )}
@@ -87,7 +87,7 @@ export function AdminDashboard() {
         </div>
 
         {isLoading ? (
-          <div className="text-center text-muted-foreground">Chargement des données...</div>
+          <div className="text-center text-muted-foreground">Loading data...</div>
         ) : (
           <div className="space-y-8">
             <div className="grid gap-6 md:grid-cols-2">

--- a/src/components/admin/AskCreateForm.tsx
+++ b/src/components/admin/AskCreateForm.tsx
@@ -21,13 +21,13 @@ const parseNumber = (value: unknown) => {
 };
 
 const formSchema = z.object({
-  challengeId: z.string().uuid("Challenge invalide"),
-  askKey: z.string().trim().min(3, "Clé trop courte").max(255).regex(/^[a-zA-Z0-9._-]+$/),
-  name: z.string().trim().min(1, "Nom requis").max(255),
-  question: z.string().trim().min(5, "Question trop courte").max(2000),
+  challengeId: z.string().uuid("Invalid challenge"),
+  askKey: z.string().trim().min(3, "Key is too short").max(255).regex(/^[a-zA-Z0-9._-]+$/),
+  name: z.string().trim().min(1, "Name is required").max(255),
+  question: z.string().trim().min(5, "Question is too short").max(2000),
   description: z.string().trim().max(2000).optional().or(z.literal("")),
-  startDate: z.string().trim().min(1, "Date de début requise"),
-  endDate: z.string().trim().min(1, "Date de fin requise"),
+  startDate: z.string().trim().min(1, "Start date is required"),
+  endDate: z.string().trim().min(1, "End date is required"),
   status: z.enum(statusOptions),
   isAnonymous: z.boolean().default(false),
   maxParticipants: z.preprocess(parseNumber, z.number().int().positive().max(10000).optional())
@@ -70,7 +70,7 @@ export function AskCreateForm({ challenges, onSubmit, isLoading }: AskCreateForm
   const handleSubmit = async (values: AskCreateFormValues) => {
     const challenge = challenges.find(item => item.id === values.challengeId);
     if (!challenge || !challenge.projectId) {
-      throw new Error("Impossible de déterminer le projet pour ce challenge");
+      throw new Error("Unable to determine the project for this challenge");
     }
 
     await onSubmit({ ...values, projectId: challenge.projectId });
@@ -92,81 +92,128 @@ export function AskCreateForm({ challenges, onSubmit, isLoading }: AskCreateForm
     <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
       <div className="flex flex-col gap-2">
         <Label htmlFor="create-challenge">Challenge</Label>
-        <select id="create-challenge" {...form.register("challengeId")}
-          className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm" disabled={isLoading}>
+        <select
+          id="create-challenge"
+          {...form.register("challengeId")}
+          className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+          disabled={isLoading}
+        >
           {challenges.map(challenge => (
-            <option key={challenge.id} value={challenge.id}>{challenge.name}</option>
+            <option key={challenge.id} value={challenge.id}>
+              {challenge.name}
+            </option>
           ))}
         </select>
       </div>
 
       <div className="flex flex-col gap-2">
-        <Label htmlFor="create-key">Clé ASK</Label>
-        <Input id="create-key" {...form.register("askKey")}
-          placeholder="team-session-001" disabled={isLoading} />
+        <Label htmlFor="create-key">ASK key</Label>
+        <Input
+          id="create-key"
+          {...form.register("askKey")}
+          placeholder="team-session-001"
+          disabled={isLoading}
+        />
         {form.formState.errors.askKey && (
           <p className="text-sm text-destructive">{form.formState.errors.askKey.message}</p>
         )}
       </div>
 
       <div className="flex flex-col gap-2">
-        <Label htmlFor="create-name">Nom</Label>
-        <Input id="create-name" {...form.register("name")}
-          placeholder="Exploration" disabled={isLoading} />
+        <Label htmlFor="create-name">Name</Label>
+        <Input
+          id="create-name"
+          {...form.register("name")}
+          placeholder="Exploration"
+          disabled={isLoading}
+        />
       </div>
 
       <div className="flex flex-col gap-2">
         <Label htmlFor="create-question">Question</Label>
-        <Textarea id="create-question" rows={3} {...form.register("question")}
-          placeholder="Quelle est la problématique ?" disabled={isLoading} />
+        <Textarea
+          id="create-question"
+          rows={3}
+          {...form.register("question")}
+          placeholder="What is the challenge?"
+          disabled={isLoading}
+        />
       </div>
 
       <div className="flex flex-col gap-2">
         <Label htmlFor="create-description">Description</Label>
-        <Textarea id="create-description" rows={2} {...form.register("description")}
-          placeholder="Contexte optionnel" disabled={isLoading} />
+        <Textarea
+          id="create-description"
+          rows={2}
+          {...form.register("description")}
+          placeholder="Optional context"
+          disabled={isLoading}
+        />
       </div>
 
       <div className="grid gap-3 md:grid-cols-2">
         <div className="flex flex-col gap-2">
-          <Label htmlFor="create-start">Début</Label>
-          <Input id="create-start" type="datetime-local" {...form.register("startDate")}
-            disabled={isLoading} />
+          <Label htmlFor="create-start">Start</Label>
+          <Input
+            id="create-start"
+            type="datetime-local"
+            {...form.register("startDate")}
+            disabled={isLoading}
+          />
         </div>
         <div className="flex flex-col gap-2">
-          <Label htmlFor="create-end">Fin</Label>
-          <Input id="create-end" type="datetime-local" {...form.register("endDate")}
-            disabled={isLoading} />
+          <Label htmlFor="create-end">End</Label>
+          <Input
+            id="create-end"
+            type="datetime-local"
+            {...form.register("endDate")}
+            disabled={isLoading}
+          />
         </div>
       </div>
 
       <div className="grid gap-3 md:grid-cols-2">
         <div className="flex flex-col gap-2">
-          <Label htmlFor="create-status">Statut</Label>
-          <select id="create-status" {...form.register("status")}
-            className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm" disabled={isLoading}>
+          <Label htmlFor="create-status">Status</Label>
+          <select
+            id="create-status"
+            {...form.register("status")}
+            className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+            disabled={isLoading}
+          >
             {statusOptions.map(status => (
-              <option key={status} value={status}>{status}</option>
+              <option key={status} value={status}>
+                {status}
+              </option>
             ))}
           </select>
         </div>
         <div className="flex items-center gap-2">
-          <input id="create-anon" type="checkbox" className="h-4 w-4"
+          <input
+            id="create-anon"
+            type="checkbox"
+            className="h-4 w-4"
             {...form.register("isAnonymous")}
-            disabled={isLoading} />
-          <Label htmlFor="create-anon">Anonyme</Label>
+            disabled={isLoading}
+          />
+          <Label htmlFor="create-anon">Anonymous</Label>
         </div>
       </div>
 
       <div className="flex flex-col gap-2">
-        <Label htmlFor="create-max">Participants max</Label>
-        <Input id="create-max" type="number" min={1}
+        <Label htmlFor="create-max">Max participants</Label>
+        <Input
+          id="create-max"
+          type="number"
+          min={1}
           {...form.register("maxParticipants", { valueAsNumber: true })}
-          placeholder="50" disabled={isLoading} />
+          placeholder="50"
+          disabled={isLoading}
+        />
       </div>
 
       <Button type="submit" className="neumorphic-raised" disabled={isLoading}>
-        Créer la session
+        Create session
       </Button>
     </form>
   );

--- a/src/components/admin/AskEditForm.tsx
+++ b/src/components/admin/AskEditForm.tsx
@@ -22,11 +22,11 @@ const parseNumber = (value: unknown) => {
 
 const formSchema = z.object({
   askId: z.string().uuid(),
-  name: z.string().trim().min(1, "Nom requis").max(255),
-  question: z.string().trim().min(5, "Question trop courte").max(2000),
+  name: z.string().trim().min(1, "Name is required").max(255),
+  question: z.string().trim().min(5, "Question is too short").max(2000),
   description: z.string().trim().max(2000).optional().or(z.literal("")),
-  startDate: z.string().trim().min(1, "Date de début requise"),
-  endDate: z.string().trim().min(1, "Date de fin requise"),
+  startDate: z.string().trim().min(1, "Start date is required"),
+  endDate: z.string().trim().min(1, "End date is required"),
   status: z.enum(statusOptions),
   isAnonymous: z.boolean(),
   maxParticipants: z.preprocess(parseNumber, z.number().int().positive().max(10000).optional())
@@ -93,79 +93,118 @@ export function AskEditForm({ asks, onSubmit, isLoading }: AskEditFormProps) {
   };
 
   if (asks.length === 0) {
-    return <p className="text-sm text-muted-foreground">Aucune session ASK enregistrée.</p>;
+    return <p className="text-sm text-muted-foreground">No ASK sessions registered yet.</p>;
   }
 
   return (
     <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
       <div className="flex flex-col gap-2">
         <Label htmlFor="edit-ask">Session</Label>
-        <select id="edit-ask" {...form.register("askId")}
-          className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm" disabled={isLoading}>
+        <select
+          id="edit-ask"
+          {...form.register("askId")}
+          className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+          disabled={isLoading}
+        >
           {asks.map(ask => (
-            <option key={ask.id} value={ask.id}>{ask.name}</option>
+            <option key={ask.id} value={ask.id}>
+              {ask.name}
+            </option>
           ))}
         </select>
       </div>
 
       <div className="flex flex-col gap-2">
-        <Label htmlFor="edit-name">Nom</Label>
-        <Input id="edit-name" {...form.register("name")}
-          disabled={isLoading} />
+        <Label htmlFor="edit-name">Name</Label>
+        <Input
+          id="edit-name"
+          {...form.register("name")}
+          disabled={isLoading}
+        />
       </div>
 
       <div className="flex flex-col gap-2">
         <Label htmlFor="edit-question">Question</Label>
-        <Textarea id="edit-question" rows={3} {...form.register("question")}
-          disabled={isLoading} />
+        <Textarea
+          id="edit-question"
+          rows={3}
+          {...form.register("question")}
+          disabled={isLoading}
+        />
       </div>
 
       <div className="flex flex-col gap-2">
         <Label htmlFor="edit-description">Description</Label>
-        <Textarea id="edit-description" rows={2} {...form.register("description")}
-          disabled={isLoading} />
+        <Textarea
+          id="edit-description"
+          rows={2}
+          {...form.register("description")}
+          disabled={isLoading}
+        />
       </div>
 
       <div className="grid gap-3 md:grid-cols-2">
         <div className="flex flex-col gap-2">
-          <Label htmlFor="edit-start">Début</Label>
-          <Input id="edit-start" type="datetime-local" {...form.register("startDate")}
-            disabled={isLoading} />
+          <Label htmlFor="edit-start">Start</Label>
+          <Input
+            id="edit-start"
+            type="datetime-local"
+            {...form.register("startDate")}
+            disabled={isLoading}
+          />
         </div>
         <div className="flex flex-col gap-2">
-          <Label htmlFor="edit-end">Fin</Label>
-          <Input id="edit-end" type="datetime-local" {...form.register("endDate")}
-            disabled={isLoading} />
+          <Label htmlFor="edit-end">End</Label>
+          <Input
+            id="edit-end"
+            type="datetime-local"
+            {...form.register("endDate")}
+            disabled={isLoading}
+          />
         </div>
       </div>
 
       <div className="grid gap-3 md:grid-cols-2">
         <div className="flex flex-col gap-2">
-          <Label htmlFor="edit-status">Statut</Label>
-          <select id="edit-status" {...form.register("status")}
-            className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm" disabled={isLoading}>
+          <Label htmlFor="edit-status">Status</Label>
+          <select
+            id="edit-status"
+            {...form.register("status")}
+            className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+            disabled={isLoading}
+          >
             {statusOptions.map(status => (
-              <option key={status} value={status}>{status}</option>
+              <option key={status} value={status}>
+                {status}
+              </option>
             ))}
           </select>
         </div>
         <div className="flex items-center gap-2">
-          <input id="edit-anon" type="checkbox" className="h-4 w-4"
+          <input
+            id="edit-anon"
+            type="checkbox"
+            className="h-4 w-4"
             {...form.register("isAnonymous")}
-            disabled={isLoading} />
-          <Label htmlFor="edit-anon">Anonyme</Label>
+            disabled={isLoading}
+          />
+          <Label htmlFor="edit-anon">Anonymous</Label>
         </div>
       </div>
 
       <div className="flex flex-col gap-2">
-        <Label htmlFor="edit-max">Participants max</Label>
-        <Input id="edit-max" type="number" min={1}
+        <Label htmlFor="edit-max">Max participants</Label>
+        <Input
+          id="edit-max"
+          type="number"
+          min={1}
           {...form.register("maxParticipants", { valueAsNumber: true })}
-          disabled={isLoading} />
+          disabled={isLoading}
+        />
       </div>
 
       <Button type="submit" className="neumorphic-raised" disabled={isLoading}>
-        Mettre à jour la session
+        Update session
       </Button>
     </form>
   );

--- a/src/components/admin/AskManager.tsx
+++ b/src/components/admin/AskManager.tsx
@@ -22,21 +22,21 @@ export function AskManager({ challenges, asks, onCreate, onUpdate, isLoading }: 
       <CardContent className="space-y-6">
         <div className="grid gap-6 md:grid-cols-2">
           <div className="space-y-4">
-            <h4 className="font-semibold text-sm text-muted-foreground">Créer une nouvelle session</h4>
+            <h4 className="font-semibold text-sm text-muted-foreground">Create a new session</h4>
             <AskCreateForm challenges={challenges} onSubmit={onCreate} isLoading={isLoading} />
           </div>
 
           <div className="space-y-4">
-            <h4 className="font-semibold text-sm text-muted-foreground">Modifier une session</h4>
+            <h4 className="font-semibold text-sm text-muted-foreground">Edit a session</h4>
             <AskEditForm asks={asks} onSubmit={onUpdate} isLoading={isLoading} />
           </div>
         </div>
 
         <div className="space-y-3">
-          <h4 className="font-semibold text-sm text-muted-foreground">Sessions ASK existantes</h4>
+          <h4 className="font-semibold text-sm text-muted-foreground">Existing ASK sessions</h4>
           <div className="space-y-2 max-h-60 overflow-y-auto pr-2">
             {asks.length === 0 && (
-              <p className="text-sm text-muted-foreground">Aucune session ASK enregistrée.</p>
+              <p className="text-sm text-muted-foreground">No ASK sessions registered yet.</p>
             )}
             {asks.map(ask => (
               <div key={ask.id} className="neumorphic-shadow p-3 rounded-lg bg-white/60">

--- a/src/components/admin/ChallengeEditor.tsx
+++ b/src/components/admin/ChallengeEditor.tsx
@@ -15,7 +15,7 @@ const statusOptions = ["open", "in_progress", "active", "closed", "archived"] as
 const priorityOptions = ["low", "medium", "high", "critical"] as const;
 
 const formSchema = z.object({
-  name: z.string().trim().min(1, "Le nom est requis").max(255),
+  name: z.string().trim().min(1, "Name is required").max(255),
   description: z.string().trim().max(2000).optional().or(z.literal("")),
   status: z.enum(statusOptions),
   priority: z.enum(priorityOptions),
@@ -86,7 +86,7 @@ export function ChallengeEditor({ challenges, users, onSave, isLoading }: Challe
       </CardHeader>
       <CardContent className="space-y-6">
         <div className="flex flex-col gap-2">
-          <Label htmlFor="challenge-select">Sélectionner un challenge</Label>
+          <Label htmlFor="challenge-select">Select a challenge</Label>
           <select
             id="challenge-select"
             value={selectedId}
@@ -105,68 +105,101 @@ export function ChallengeEditor({ challenges, users, onSave, isLoading }: Challe
         {selectedChallenge ? (
           <form onSubmit={form.handleSubmit(handleSubmit)} className="grid gap-4 md:grid-cols-2">
             <div className="flex flex-col gap-2 md:col-span-2">
-              <Label htmlFor="challenge-name">Nom</Label>
-              <Input id="challenge-name" {...form.register("name")}
-                disabled={isLoading} />
+              <Label htmlFor="challenge-name">Name</Label>
+              <Input
+                id="challenge-name"
+                {...form.register("name")}
+                disabled={isLoading}
+              />
             </div>
 
             <div className="flex flex-col gap-2 md:col-span-2">
               <Label htmlFor="challenge-description">Description</Label>
-              <Textarea id="challenge-description" rows={3} {...form.register("description")}
-                disabled={isLoading} />
+              <Textarea
+                id="challenge-description"
+                rows={3}
+                {...form.register("description")}
+                disabled={isLoading}
+              />
             </div>
 
             <div className="flex flex-col gap-2">
-              <Label htmlFor="challenge-status">Statut</Label>
-              <select id="challenge-status" {...form.register("status")}
-                className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm" disabled={isLoading}>
+              <Label htmlFor="challenge-status">Status</Label>
+              <select
+                id="challenge-status"
+                {...form.register("status")}
+                className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+                disabled={isLoading}
+              >
                 {statusOptions.map(status => (
-                  <option key={status} value={status}>{status}</option>
+                  <option key={status} value={status}>
+                    {status}
+                  </option>
                 ))}
               </select>
             </div>
 
             <div className="flex flex-col gap-2">
-              <Label htmlFor="challenge-priority">Priorité</Label>
-              <select id="challenge-priority" {...form.register("priority")}
-                className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm" disabled={isLoading}>
+              <Label htmlFor="challenge-priority">Priority</Label>
+              <select
+                id="challenge-priority"
+                {...form.register("priority")}
+                className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+                disabled={isLoading}
+              >
                 {priorityOptions.map(priority => (
-                  <option key={priority} value={priority}>{priority}</option>
+                  <option key={priority} value={priority}>
+                    {priority}
+                  </option>
                 ))}
               </select>
             </div>
 
             <div className="flex flex-col gap-2">
-              <Label htmlFor="challenge-category">Catégorie</Label>
-              <Input id="challenge-category" {...form.register("category")}
-                placeholder="Opérationnel, Technique…" disabled={isLoading} />
+              <Label htmlFor="challenge-category">Category</Label>
+              <Input
+                id="challenge-category"
+                {...form.register("category")}
+                placeholder="Operational, Technical…"
+                disabled={isLoading}
+              />
             </div>
 
             <div className="flex flex-col gap-2">
-              <Label htmlFor="challenge-owner">Assigné à</Label>
-              <select id="challenge-owner" {...form.register("assignedTo")}
-                className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm" disabled={isLoading}>
-                <option value="">Aucun</option>
+              <Label htmlFor="challenge-owner">Assigned to</Label>
+              <select
+                id="challenge-owner"
+                {...form.register("assignedTo")}
+                className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+                disabled={isLoading}
+              >
+                <option value="">None</option>
                 {users.map(user => (
-                  <option key={user.id} value={user.id}>{user.fullName || user.email}</option>
+                  <option key={user.id} value={user.id}>
+                    {user.fullName || user.email}
+                  </option>
                 ))}
               </select>
             </div>
 
             <div className="flex flex-col gap-2">
-              <Label htmlFor="challenge-due">Échéance</Label>
-              <Input id="challenge-due" type="datetime-local" {...form.register("dueDate")}
-                disabled={isLoading} />
+              <Label htmlFor="challenge-due">Due date</Label>
+              <Input
+                id="challenge-due"
+                type="datetime-local"
+                {...form.register("dueDate")}
+                disabled={isLoading}
+              />
             </div>
 
             <div className="md:col-span-2 flex justify-end">
               <Button type="submit" className="neumorphic-raised" disabled={isLoading}>
-                Mettre à jour le challenge
+                Update challenge
               </Button>
             </div>
           </form>
         ) : (
-          <p className="text-sm text-muted-foreground">Aucun challenge à afficher.</p>
+          <p className="text-sm text-muted-foreground">No challenges to display.</p>
         )}
       </CardContent>
     </Card>

--- a/src/components/admin/ClientManager.tsx
+++ b/src/components/admin/ClientManager.tsx
@@ -10,8 +10,8 @@ import { Button } from "@/components/ui/button";
 import { type ClientRecord } from "@/types";
 
 const formSchema = z.object({
-  name: z.string().trim().min(1, "Le nom est requis").max(255),
-  email: z.string().trim().email("Email invalide").max(255).optional().or(z.literal("")),
+  name: z.string().trim().min(1, "Name is required").max(255),
+  email: z.string().trim().email("Invalid email").max(255).optional().or(z.literal("")),
   company: z.string().trim().max(255).optional().or(z.literal("")),
   industry: z.string().trim().max(100).optional().or(z.literal(""))
 });
@@ -43,9 +43,13 @@ export function ClientManager({ clients, onCreate, isLoading }: ClientManagerPro
       <CardContent className="space-y-6">
         <form onSubmit={form.handleSubmit(handleSubmit)} className="grid gap-4 md:grid-cols-2">
           <div className="flex flex-col gap-2">
-            <Label htmlFor="client-name">Nom</Label>
-            <Input id="client-name" {...form.register("name")}
-              placeholder="TechCorp Solutions" disabled={isLoading} />
+            <Label htmlFor="client-name">Name</Label>
+            <Input
+              id="client-name"
+              {...form.register("name")}
+              placeholder="TechCorp Solutions"
+              disabled={isLoading}
+            />
             {form.formState.errors.name && (
               <p className="text-sm text-destructive">{form.formState.errors.name.message}</p>
             )}
@@ -61,36 +65,44 @@ export function ClientManager({ clients, onCreate, isLoading }: ClientManagerPro
           </div>
 
           <div className="flex flex-col gap-2">
-            <Label htmlFor="client-company">Entreprise</Label>
-            <Input id="client-company" {...form.register("company")}
-              placeholder="Nom de la société" disabled={isLoading} />
+            <Label htmlFor="client-company">Company</Label>
+            <Input
+              id="client-company"
+              {...form.register("company")}
+              placeholder="Company name"
+              disabled={isLoading}
+            />
           </div>
 
           <div className="flex flex-col gap-2">
-            <Label htmlFor="client-industry">Secteur</Label>
-            <Input id="client-industry" {...form.register("industry")}
-              placeholder="Industrie" disabled={isLoading} />
+            <Label htmlFor="client-industry">Industry</Label>
+            <Input
+              id="client-industry"
+              {...form.register("industry")}
+              placeholder="Industry"
+              disabled={isLoading}
+            />
           </div>
 
           <div className="md:col-span-2 flex justify-end">
             <Button type="submit" className="neumorphic-raised" disabled={isLoading}>
-              Ajouter le client
+              Add client
             </Button>
           </div>
         </form>
 
         <div className="space-y-3">
-          <h4 className="font-semibold text-sm text-muted-foreground">Clients existants</h4>
+          <h4 className="font-semibold text-sm text-muted-foreground">Existing clients</h4>
           <div className="space-y-2 max-h-60 overflow-y-auto pr-2">
             {clients.length === 0 && (
-              <p className="text-sm text-muted-foreground">Aucun client enregistré pour le moment.</p>
+              <p className="text-sm text-muted-foreground">No clients registered yet.</p>
             )}
             {clients.map(client => (
               <div key={client.id} className="neumorphic-shadow p-3 rounded-lg bg-white/60">
                 <div className="flex items-center justify-between">
                   <div>
                     <p className="font-medium">{client.name}</p>
-                    <p className="text-xs text-muted-foreground">{client.email || "Email non renseigné"}</p>
+                    <p className="text-xs text-muted-foreground">{client.email || "Email not provided"}</p>
                   </div>
                   <span className="text-xs px-2 py-1 rounded-full bg-primary/10 text-primary">
                     {client.status}

--- a/src/components/admin/ProjectManager.tsx
+++ b/src/components/admin/ProjectManager.tsx
@@ -14,11 +14,11 @@ import { type ClientRecord, type ManagedUser, type ProjectRecord } from "@/types
 const statuses = ["active", "paused", "completed", "archived"] as const;
 
 const formSchema = z.object({
-  name: z.string().trim().min(1, "Le nom est requis").max(255),
+  name: z.string().trim().min(1, "Name is required").max(255),
   description: z.string().trim().max(1000).optional().or(z.literal("")),
-  clientId: z.string().uuid("Client invalide"),
-  startDate: z.string().trim().min(1, "Date de début requise"),
-  endDate: z.string().trim().min(1, "Date de fin requise"),
+  clientId: z.string().uuid("Invalid client"),
+  startDate: z.string().trim().min(1, "Start date is required"),
+  endDate: z.string().trim().min(1, "End date is required"),
   status: z.enum(statuses),
   createdBy: z.string().trim().optional()
 });
@@ -73,14 +73,18 @@ export function ProjectManager({ clients, users, projects, onCreate, isLoading }
   return (
     <Card className="glass-card">
       <CardHeader>
-        <CardTitle>Projets</CardTitle>
+        <CardTitle>Projects</CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
         <form onSubmit={form.handleSubmit(handleSubmit)} className="grid gap-4 md:grid-cols-2">
           <div className="flex flex-col gap-2 md:col-span-2">
-            <Label htmlFor="project-name">Nom du projet</Label>
-            <Input id="project-name" {...form.register("name")}
-              placeholder="Transformation digitale" disabled={isLoading} />
+            <Label htmlFor="project-name">Project name</Label>
+            <Input
+              id="project-name"
+              {...form.register("name")}
+              placeholder="Digital transformation"
+              disabled={isLoading}
+            />
             {form.formState.errors.name && (
               <p className="text-sm text-destructive">{form.formState.errors.name.message}</p>
             )}
@@ -88,71 +92,102 @@ export function ProjectManager({ clients, users, projects, onCreate, isLoading }
 
           <div className="flex flex-col gap-2 md:col-span-2">
             <Label htmlFor="project-description">Description</Label>
-            <Textarea id="project-description" rows={3} {...form.register("description")}
-              placeholder="Objectifs du projet" disabled={isLoading} />
+            <Textarea
+              id="project-description"
+              rows={3}
+              {...form.register("description")}
+              placeholder="Project goals"
+              disabled={isLoading}
+            />
           </div>
 
           <div className="flex flex-col gap-2">
             <Label htmlFor="project-client">Client</Label>
-            <select id="project-client" {...form.register("clientId")}
-              className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm" disabled={isLoading}>
+            <select
+              id="project-client"
+              {...form.register("clientId")}
+              className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+              disabled={isLoading}
+            >
               {clients.map(client => (
-                <option key={client.id} value={client.id}>{client.name}</option>
+                <option key={client.id} value={client.id}>
+                  {client.name}
+                </option>
               ))}
             </select>
           </div>
 
           <div className="flex flex-col gap-2">
-            <Label htmlFor="project-owner">Créé par</Label>
-            <select id="project-owner" {...form.register("createdBy")}
-              className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm" disabled={isLoading}>
-              <option value="">Aucun</option>
+            <Label htmlFor="project-owner">Created by</Label>
+            <select
+              id="project-owner"
+              {...form.register("createdBy")}
+              className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+              disabled={isLoading}
+            >
+              <option value="">None</option>
               {users.map(user => (
-                <option key={user.id} value={user.id}>{user.fullName || user.email}</option>
+                <option key={user.id} value={user.id}>
+                  {user.fullName || user.email}
+                </option>
               ))}
             </select>
           </div>
 
           <div className="flex flex-col gap-2">
-            <Label htmlFor="project-start">Début</Label>
-            <Input id="project-start" type="datetime-local" {...form.register("startDate")}
-              disabled={isLoading} />
+            <Label htmlFor="project-start">Start</Label>
+            <Input
+              id="project-start"
+              type="datetime-local"
+              {...form.register("startDate")}
+              disabled={isLoading}
+            />
             {form.formState.errors.startDate && (
               <p className="text-sm text-destructive">{form.formState.errors.startDate.message}</p>
             )}
           </div>
 
           <div className="flex flex-col gap-2">
-            <Label htmlFor="project-end">Fin</Label>
-            <Input id="project-end" type="datetime-local" {...form.register("endDate")}
-              disabled={isLoading} />
+            <Label htmlFor="project-end">End</Label>
+            <Input
+              id="project-end"
+              type="datetime-local"
+              {...form.register("endDate")}
+              disabled={isLoading}
+            />
             {form.formState.errors.endDate && (
               <p className="text-sm text-destructive">{form.formState.errors.endDate.message}</p>
             )}
           </div>
 
           <div className="flex flex-col gap-2">
-            <Label htmlFor="project-status">Statut</Label>
-            <select id="project-status" {...form.register("status")}
-              className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm" disabled={isLoading}>
+            <Label htmlFor="project-status">Status</Label>
+            <select
+              id="project-status"
+              {...form.register("status")}
+              className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+              disabled={isLoading}
+            >
               {statuses.map(status => (
-                <option key={status} value={status}>{status}</option>
+                <option key={status} value={status}>
+                  {status}
+                </option>
               ))}
             </select>
           </div>
 
           <div className="md:col-span-2 flex justify-end">
             <Button type="submit" className="neumorphic-raised" disabled={isLoading}>
-              Créer le projet
+              Create project
             </Button>
           </div>
         </form>
 
         <div className="space-y-3">
-          <h4 className="font-semibold text-sm text-muted-foreground">Projets récents</h4>
+          <h4 className="font-semibold text-sm text-muted-foreground">Recent projects</h4>
           <div className="space-y-2 max-h-60 overflow-y-auto pr-2">
             {projects.length === 0 && (
-              <p className="text-sm text-muted-foreground">Aucun projet enregistré pour le moment.</p>
+              <p className="text-sm text-muted-foreground">No projects registered yet.</p>
             )}
             {projects.map(project => (
               <div key={project.id} className="neumorphic-shadow p-3 rounded-lg bg-white/60">

--- a/src/components/admin/UserManager.tsx
+++ b/src/components/admin/UserManager.tsx
@@ -12,7 +12,7 @@ import { type ClientRecord, type ManagedUser } from "@/types";
 const roles = ["full_admin", "project_admin", "facilitator", "manager", "participant", "user"] as const;
 
 const formSchema = z.object({
-  email: z.string().trim().email("Email invalide").max(255),
+  email: z.string().trim().email("Invalid email").max(255),
   firstName: z.string().trim().max(100).optional().or(z.literal("")),
   lastName: z.string().trim().max(100).optional().or(z.literal("")),
   role: z.enum(roles),
@@ -50,71 +50,100 @@ export function UserManager({ clients, users, onCreate, isLoading }: UserManager
   return (
     <Card className="glass-card">
       <CardHeader>
-        <CardTitle>Utilisateurs</CardTitle>
+        <CardTitle>Users</CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
         <form onSubmit={form.handleSubmit(handleSubmit)} className="grid gap-4 md:grid-cols-3">
           <div className="flex flex-col gap-2">
             <Label htmlFor="user-email">Email</Label>
-            <Input id="user-email" type="email" {...form.register("email")}
-              placeholder="utilisateur@client.com" disabled={isLoading} />
+            <Input
+              id="user-email"
+              type="email"
+              {...form.register("email")}
+              placeholder="user@client.com"
+              disabled={isLoading}
+            />
             {form.formState.errors.email && (
               <p className="text-sm text-destructive">{form.formState.errors.email.message}</p>
             )}
           </div>
 
           <div className="flex flex-col gap-2">
-            <Label htmlFor="user-first">Prénom</Label>
-            <Input id="user-first" {...form.register("firstName")}
-              placeholder="Prénom" disabled={isLoading} />
+            <Label htmlFor="user-first">First name</Label>
+            <Input
+              id="user-first"
+              {...form.register("firstName")}
+              placeholder="First name"
+              disabled={isLoading}
+            />
           </div>
 
           <div className="flex flex-col gap-2">
-            <Label htmlFor="user-last">Nom</Label>
-            <Input id="user-last" {...form.register("lastName")}
-              placeholder="Nom" disabled={isLoading} />
+            <Label htmlFor="user-last">Last name</Label>
+            <Input
+              id="user-last"
+              {...form.register("lastName")}
+              placeholder="Last name"
+              disabled={isLoading}
+            />
           </div>
 
           <div className="flex flex-col gap-2">
-            <Label htmlFor="user-role">Rôle</Label>
-            <select id="user-role" {...form.register("role")}
-              className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm" disabled={isLoading}>
+            <Label htmlFor="user-role">Role</Label>
+            <select
+              id="user-role"
+              {...form.register("role")}
+              className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+              disabled={isLoading}
+            >
               {roles.map(role => (
-                <option key={role} value={role}>{role}</option>
+                <option key={role} value={role}>
+                  {role}
+                </option>
               ))}
             </select>
           </div>
 
           <div className="flex flex-col gap-2">
             <Label htmlFor="user-client">Client</Label>
-            <select id="user-client" {...form.register("clientId")}
-              className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm" disabled={isLoading}>
-              <option value="">Aucun</option>
+            <select
+              id="user-client"
+              {...form.register("clientId")}
+              className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+              disabled={isLoading}
+            >
+              <option value="">None</option>
               {clients.map(client => (
-                <option key={client.id} value={client.id}>{client.name}</option>
+                <option key={client.id} value={client.id}>
+                  {client.name}
+                </option>
               ))}
             </select>
           </div>
 
           <div className="flex items-center gap-2">
-            <input id="user-active" type="checkbox" className="h-4 w-4"
+            <input
+              id="user-active"
+              type="checkbox"
+              className="h-4 w-4"
               {...form.register("isActive")}
-              disabled={isLoading} />
-            <Label htmlFor="user-active">Actif</Label>
+              disabled={isLoading}
+            />
+            <Label htmlFor="user-active">Active</Label>
           </div>
 
           <div className="md:col-span-3 flex justify-end">
             <Button type="submit" className="neumorphic-raised" disabled={isLoading}>
-              Créer l'utilisateur
+              Create user
             </Button>
           </div>
         </form>
 
         <div className="space-y-3">
-          <h4 className="font-semibold text-sm text-muted-foreground">Derniers utilisateurs</h4>
+          <h4 className="font-semibold text-sm text-muted-foreground">Recent users</h4>
           <div className="space-y-2 max-h-60 overflow-y-auto pr-2">
             {users.length === 0 && (
-              <p className="text-sm text-muted-foreground">Aucun utilisateur enregistré pour le moment.</p>
+              <p className="text-sm text-muted-foreground">No users registered yet.</p>
             )}
             {users.map(user => (
               <div key={user.id} className="neumorphic-shadow p-3 rounded-lg bg-white/60">
@@ -128,8 +157,8 @@ export function UserManager({ clients, users, onCreate, isLoading }: UserManager
                   </span>
                 </div>
                 <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
-                  <span>{user.clientName || "Sans client"}</span>
-                  <span>{user.isActive ? "Actif" : "Inactif"}</span>
+                  <span>{user.clientName || "No client"}</span>
+                  <span>{user.isActive ? "Active" : "Inactive"}</span>
                 </div>
               </div>
             ))}

--- a/src/components/admin/useAdminResources.ts
+++ b/src/components/admin/useAdminResources.ts
@@ -32,7 +32,7 @@ async function request<T>(url: string, options?: RequestInit): Promise<T> {
 
   const payload = await response.json();
   if (!response.ok || !payload.success) {
-    throw new Error(payload.error || payload.message || "Requête échouée");
+    throw new Error(payload.error || payload.message || "Request failed");
   }
   return payload.data as T;
 }
@@ -66,7 +66,7 @@ export function useAdminResources() {
       } catch (error) {
         setFeedback({
           type: "error",
-          message: error instanceof Error ? error.message : "Chargement impossible"
+          message: error instanceof Error ? error.message : "Unable to load data"
         });
       } finally {
         setIsLoading(false);
@@ -85,7 +85,7 @@ export function useAdminResources() {
     } catch (error) {
       setFeedback({
         type: "error",
-        message: error instanceof Error ? error.message : "Une erreur est survenue"
+        message: error instanceof Error ? error.message : "An error occurred"
       });
     } finally {
       setIsBusy(false);
@@ -107,39 +107,39 @@ export function useAdminResources() {
       await request("/api/admin/clients", { method: "POST", body: JSON.stringify(values) });
       const data = await request<ClientRecord[]>("/api/admin/clients");
       setClients(data ?? []);
-    }, "Client créé avec succès");
+    }, "Client created successfully");
 
   const createUser = (values: UserFormValues) =>
     handleAction(async () => {
       await request("/api/admin/users", { method: "POST", body: JSON.stringify(values) });
       const data = await request<ManagedUser[]>("/api/admin/users");
       setUsers(data ?? []);
-    }, "Utilisateur créé");
+    }, "User created");
 
   const createProject = (values: ProjectFormValues) =>
     handleAction(async () => {
       await request("/api/admin/projects", { method: "POST", body: JSON.stringify(values) });
       const data = await request<ProjectRecord[]>("/api/admin/projects");
       setProjects(data ?? []);
-    }, "Projet enregistré");
+    }, "Project saved");
 
   const updateChallenge = (challengeId: string, values: ChallengeFormValues) =>
     handleAction(async () => {
       await request(`/api/admin/challenges/${challengeId}`, { method: "PATCH", body: JSON.stringify(values) });
       await refreshChallenges();
-    }, "Challenge mis à jour");
+    }, "Challenge updated");
 
   const createAsk = (values: AskCreateFormValues & { projectId: string }) =>
     handleAction(async () => {
       await request("/api/admin/asks", { method: "POST", body: JSON.stringify(values) });
       await refreshAsks();
-    }, "Session ASK créée");
+    }, "ASK session created");
 
   const updateAsk = (askId: string, values: Omit<AskEditFormValues, "askId">) =>
     handleAction(async () => {
       await request(`/api/admin/asks/${askId}`, { method: "PATCH", body: JSON.stringify(values) });
       await refreshAsks();
-    }, "Session ASK mise à jour");
+    }, "ASK session updated");
 
   return {
     clients,


### PR DESCRIPTION
## Summary
- translate admin dashboard copy and notifications to English
- update admin management forms for clients, users, projects, asks, and challenges with English labels, placeholders, and validation messages
- align admin resource feedback messages with the English localization and clean up helper formatting

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68cfffab537c832abc36ecb81b583e8a