### PR TITLE
Enhance admin dashboard navigation and styling

### DIFF
--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { MouseEvent as ReactMouseEvent } from "react";
+import type { MouseEvent as ReactMouseEvent, RefObject } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -100,7 +100,10 @@ const navigationItems = [
   { label: "Users", icon: Users, targetId: "section-users" },
   { label: "Insights", icon: ClipboardList, targetId: "section-insights" },
   { label: "Settings", icon: Settings, targetId: "section-settings" }
-];
+] as const;
+
+type SectionId = (typeof navigationItems)[number]["targetId"];
+type SectionLabel = (typeof navigationItems)[number]["label"];
 
 function formatDateTime(value: string | null | undefined) {
   if (!value) {
@@ -157,7 +160,7 @@ export function AdminDashboard() {
   const [showProjectForm, setShowProjectForm] = useState(false);
   const [showAskForm, setShowAskForm] = useState(false);
   const [manualAskKey, setManualAskKey] = useState(false);
-  const [activeSection, setActiveSection] = useState(navigationItems[0].label);
+  const [activeSection, setActiveSection] = useState<SectionLabel>(navigationItems[0].label);
   const [columnWidths, setColumnWidths] = useState<ColumnWidths>(defaultColumnWidths);
   const [isLargeScreen, setIsLargeScreen] = useState(false);
 
@@ -170,7 +173,7 @@ export function AdminDashboard() {
   const insightsRef = useRef<HTMLDivElement>(null);
   const settingsRef = useRef<HTMLDivElement>(null);
 
-  const sectionRefMap = useMemo(
+  const sectionRefMap = useMemo<Record<SectionId, RefObject<HTMLDivElement>>>(
     () => ({
       "section-dashboard": dashboardRef,
       "section-clients": clientsRef,
@@ -181,7 +184,7 @@ export function AdminDashboard() {
       "section-insights": insightsRef,
       "section-settings": settingsRef
     }),
-    [dashboardRef, clientsRef, projectsRef, challengesRef, asksRef, usersRef, insightsRef, settingsRef]
+    []
   );
 
   const resizeStartXRef = useRef(0);

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -361,10 +361,24 @@ export function AdminDashboard() {
     [clients.length, projects.length, challenges.length, asks.length]
   );
 
-  const columnTemplate = useMemo(
-    () => (isLargeScreen ? `${columnWidths[0]}px ${columnWidths[1]}px ${columnWidths[2]}px` : undefined),
-    [columnWidths, isLargeScreen]
-  );
+  const columnTemplate = useMemo(() => {
+    if (!isLargeScreen) {
+      return undefined;
+    }
+
+    const total = columnWidths.reduce((sum, width) => sum + width, 0);
+
+    if (total === 0) {
+      return undefined;
+    }
+
+    return columnWidths
+      .map((width, index) => {
+        const fraction = width / total;
+        return `minmax(${minColumnWidths[index]}px, ${fraction}fr)`;
+      })
+      .join(" ");
+  }, [columnWidths, isLargeScreen]);
 
   const handleResizeMove = useCallback((event: MouseEvent) => {
     const index = activeResizeIndexRef.current;

--- a/src/components/admin/AskCreateForm.tsx
+++ b/src/components/admin/AskCreateForm.tsx
@@ -95,7 +95,7 @@ export function AskCreateForm({ challenges, onSubmit, isLoading }: AskCreateForm
         <select
           id="create-challenge"
           {...form.register("challengeId")}
-          className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+          className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm text-slate-900"
           disabled={isLoading}
         >
           {challenges.map(challenge => (
@@ -178,7 +178,7 @@ export function AskCreateForm({ challenges, onSubmit, isLoading }: AskCreateForm
           <select
             id="create-status"
             {...form.register("status")}
-            className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+            className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm text-slate-900"
             disabled={isLoading}
           >
             {statusOptions.map(status => (

--- a/src/components/admin/AskEditForm.tsx
+++ b/src/components/admin/AskEditForm.tsx
@@ -103,7 +103,7 @@ export function AskEditForm({ asks, onSubmit, isLoading }: AskEditFormProps) {
         <select
           id="edit-ask"
           {...form.register("askId")}
-          className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+          className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm text-slate-900"
           disabled={isLoading}
         >
           {asks.map(ask => (
@@ -170,7 +170,7 @@ export function AskEditForm({ asks, onSubmit, isLoading }: AskEditFormProps) {
           <select
             id="edit-status"
             {...form.register("status")}
-            className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+            className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm text-slate-900"
             disabled={isLoading}
           >
             {statusOptions.map(status => (

--- a/src/components/admin/ChallengeEditor.tsx
+++ b/src/components/admin/ChallengeEditor.tsx
@@ -91,7 +91,7 @@ export function ChallengeEditor({ challenges, users, onSave, isLoading }: Challe
             id="challenge-select"
             value={selectedId}
             onChange={event => setSelectedId(event.target.value)}
-            className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+            className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm text-slate-900"
             disabled={isLoading}
           >
             {challenges.map(challenge => (
@@ -128,7 +128,7 @@ export function ChallengeEditor({ challenges, users, onSave, isLoading }: Challe
               <select
                 id="challenge-status"
                 {...form.register("status")}
-                className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+                className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm text-slate-900"
                 disabled={isLoading}
               >
                 {statusOptions.map(status => (
@@ -144,7 +144,7 @@ export function ChallengeEditor({ challenges, users, onSave, isLoading }: Challe
               <select
                 id="challenge-priority"
                 {...form.register("priority")}
-                className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+                className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm text-slate-900"
                 disabled={isLoading}
               >
                 {priorityOptions.map(priority => (
@@ -170,7 +170,7 @@ export function ChallengeEditor({ challenges, users, onSave, isLoading }: Challe
               <select
                 id="challenge-owner"
                 {...form.register("assignedTo")}
-                className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+                className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm text-slate-900"
                 disabled={isLoading}
               >
                 <option value="">None</option>

--- a/src/components/admin/ProjectManager.tsx
+++ b/src/components/admin/ProjectManager.tsx
@@ -106,7 +106,7 @@ export function ProjectManager({ clients, users, projects, onCreate, isLoading }
             <select
               id="project-client"
               {...form.register("clientId")}
-              className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+              className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm text-slate-900"
               disabled={isLoading}
             >
               {clients.map(client => (
@@ -122,7 +122,7 @@ export function ProjectManager({ clients, users, projects, onCreate, isLoading }
             <select
               id="project-owner"
               {...form.register("createdBy")}
-              className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+              className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm text-slate-900"
               disabled={isLoading}
             >
               <option value="">None</option>
@@ -165,7 +165,7 @@ export function ProjectManager({ clients, users, projects, onCreate, isLoading }
             <select
               id="project-status"
               {...form.register("status")}
-              className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+              className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm text-slate-900"
               disabled={isLoading}
             >
               {statuses.map(status => (

--- a/src/components/admin/UserManager.tsx
+++ b/src/components/admin/UserManager.tsx
@@ -93,7 +93,7 @@ export function UserManager({ clients, users, onCreate, isLoading }: UserManager
             <select
               id="user-role"
               {...form.register("role")}
-              className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+              className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm text-slate-900"
               disabled={isLoading}
             >
               {roles.map(role => (
@@ -109,7 +109,7 @@ export function UserManager({ clients, users, onCreate, isLoading }: UserManager
             <select
               id="user-client"
               {...form.register("clientId")}
-              className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm"
+              className="h-10 rounded-md border border-border bg-white/70 px-3 text-sm text-slate-900"
               disabled={isLoading}
             >
               <option value="">None</option>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -14,7 +14,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-slate-900 ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -13,7 +13,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 resize-none",
+          "flex min-h-[80px] w-full resize-none rounded-md border border-input bg-background px-3 py-2 text-sm text-slate-900 ring-offset-background placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}


### PR DESCRIPTION
## Summary
- wire the admin navigation to real sections, add column resizing, and extend the dashboard with users/insights/settings panels
- default form inputs and select fields to dark text on light backgrounds across the admin experience
- update shared input components to enforce dark text on light backgrounds for readability

## Testing
- npm run lint *(fails: requires interactive ESLint setup and was canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68db7cf38ed8832a8a854e48c2c31b73