### PR TITLE
Refocus relationship canvas on challenges

### DIFF
--- a/src/components/admin/AskRelationshipCanvas.tsx
+++ b/src/components/admin/AskRelationshipCanvas.tsx
@@ -10,7 +10,14 @@ import {
   type ProjectRecord
 } from "@/types";
 
-type LayoutNodeType = "project" | "challenge" | "ask";
+type LayoutNodeType = "project" | "challenge";
+
+interface ChallengeAskSummary {
+  id: string;
+  title: string;
+  question: string;
+  status?: string | null;
+}
 
 interface LayoutNode {
   id: string;
@@ -26,8 +33,8 @@ interface LayoutNode {
   meta?: string;
   projectId?: string;
   challengeId?: string;
-  askId?: string;
   depth: number;
+  asks?: ChallengeAskSummary[];
 }
 
 interface LayoutEdge {
@@ -55,12 +62,12 @@ interface AskRelationshipCanvasProps {
 
 const PROJECT_NODE = { width: 260, height: 104 } as const;
 const CHALLENGE_NODE = { width: 240, height: 92 } as const;
-const ASK_NODE = { width: 220, height: 84 } as const;
-
 const PROJECT_COLUMN_GAP = 420;
 const LEVEL_GAP_X = 220;
 const ROW_GAP_Y = 150;
-const ASK_GAP_Y = 120;
+const ASK_SECTION_PADDING = 28;
+const ASK_SUMMARY_HEIGHT = 72;
+const ASK_SUMMARY_GAP = 12;
 
 const INITIAL_MARGIN_X = 160;
 const INITIAL_MARGIN_Y = 120;
@@ -192,6 +199,18 @@ function buildLayout(
     const placeChallenge = (challenge: ChallengeRecord, depth: number, parentNodeId: string) => {
       const dueLabel = formatDate(challenge.dueDate);
 
+      const askSessions = (askByChallenge.get(challenge.id) ?? []).sort((a, b) => {
+        const startA = new Date(a.startDate).getTime();
+        const startB = new Date(b.startDate).getTime();
+        return startA - startB;
+      });
+
+      const askSectionHeight = askSessions.length > 0
+        ? ASK_SECTION_PADDING +
+          askSessions.length * ASK_SUMMARY_HEIGHT +
+          Math.max(askSessions.length - 1, 0) * ASK_SUMMARY_GAP
+        : 0;
+
       const challengeNode: LayoutNode = {
         id: `challenge-${challenge.id}`,
         entityId: challenge.id,
@@ -199,52 +218,26 @@ function buildLayout(
         x: baseX + depth * LEVEL_GAP_X,
         y: cursorY,
         width: CHALLENGE_NODE.width,
-        height: CHALLENGE_NODE.height,
+        height: CHALLENGE_NODE.height + askSectionHeight,
         label: challenge.name,
         subtitle: challenge.description ?? undefined,
         status: challenge.status,
         meta: dueLabel ? `Échéance ${dueLabel}` : undefined,
         projectId: project.id,
         challengeId: challenge.id,
-        depth
+        depth,
+        asks: askSessions.map(ask => ({
+          id: ask.id,
+          title: ask.name,
+          question: ask.question,
+          status: ask.status
+        }))
       };
 
       nodes.push(challengeNode);
       edges.push({ id: `${parentNodeId}->${challengeNode.id}`, from: parentNodeId, to: challengeNode.id });
 
-      cursorY += ROW_GAP_Y;
       let localBottom = challengeNode.y + challengeNode.height;
-
-      const askSessions = (askByChallenge.get(challenge.id) ?? []).sort((a, b) => {
-        const startA = new Date(a.startDate).getTime();
-        const startB = new Date(b.startDate).getTime();
-        return startA - startB;
-      });
-
-      askSessions.forEach((ask, index) => {
-        const askNodeY = localBottom + 32 + index * ASK_GAP_Y;
-        const askNode: LayoutNode = {
-          id: `ask-${ask.id}`,
-          entityId: ask.id,
-          type: "ask",
-          x: challengeNode.x + LEVEL_GAP_X,
-          y: askNodeY,
-          width: ASK_NODE.width,
-          height: ASK_NODE.height,
-          label: ask.name,
-          subtitle: ask.question,
-          status: ask.status,
-          meta: `${formatDate(ask.startDate) ?? ""} → ${formatDate(ask.endDate) ?? ""}`.trim(),
-          projectId: ask.projectId,
-          challengeId: ask.challengeId ?? undefined,
-          askId: ask.id,
-          depth: depth + 1
-        };
-
-        nodes.push(askNode);
-        edges.push({ id: `${challengeNode.id}->${askNode.id}`, from: challengeNode.id, to: askNode.id });
-        localBottom = Math.max(localBottom, askNode.y + askNode.height);
-      });
 
       const childChallenges = challengeChildren.get(challenge.id) ?? [];
 
@@ -297,7 +290,9 @@ export function AskRelationshipCanvas({
 
   const focusNode = useMemo(() => {
     if (focusAskId) {
-      const node = nodes.find(item => item.askId === focusAskId);
+      const node = nodes.find(
+        item => item.type === "challenge" && item.asks?.some(ask => ask.id === focusAskId)
+      );
       if (node) {
         return node;
       }
@@ -532,9 +527,6 @@ export function AskRelationshipCanvas({
     if (node.type === "challenge" && node.challengeId) {
       onChallengeSelect?.(node.challengeId);
     }
-    if (node.type === "ask" && node.askId) {
-      onAskSelect?.(node.askId);
-    }
   };
 
   if (nodes.length === 0) {
@@ -632,16 +624,12 @@ export function AskRelationshipCanvas({
             const isFocused =
               (focusProjectId && node.projectId === focusProjectId && node.type === "project") ||
               (focusChallengeId && node.challengeId === focusChallengeId && node.type === "challenge") ||
-              (focusAskId && node.askId === focusAskId && node.type === "ask");
+              (focusAskId &&
+                node.type === "challenge" &&
+                node.asks?.some(ask => ask.id === focusAskId));
 
             const statusColor =
-              node.type === "ask"
-                ? node.status === "active"
-                  ? "bg-emerald-500/20 text-emerald-200"
-                  : node.status === "closed"
-                  ? "bg-rose-500/20 text-rose-200"
-                  : "bg-indigo-500/20 text-indigo-100"
-                : node.type === "challenge"
+              node.type === "challenge"
                 ? node.status === "active" || node.status === "in_progress"
                   ? "bg-sky-500/20 text-sky-100"
                   : node.status === "closed"
@@ -662,19 +650,13 @@ export function AskRelationshipCanvas({
                   }
                 }}
                 className={cn(
-                  "absolute cursor-pointer rounded-3xl border border-white/10 bg-slate-900/80 p-4 shadow-lg transition-all", 
+                  "absolute cursor-pointer rounded-3xl border border-white/10 bg-slate-900/80 p-4 shadow-lg transition-all",
                   "backdrop-blur",
                   node.type === "project" && "hover:border-indigo-400/80",
                   node.type === "challenge" && "hover:border-fuchsia-400/80",
-                  node.type === "ask" && "hover:border-emerald-400/80",
                   isFocused ? "ring-2 ring-offset-2 ring-offset-slate-950" : "ring-0",
-                  isFocused &&
-                    (node.type === "project"
-                      ? "ring-indigo-400"
-                      : node.type === "challenge"
-                      ? "ring-fuchsia-400"
-                      : "ring-emerald-400"),
-                  node.type === "project" ? "w-[260px]" : node.type === "challenge" ? "w-[240px]" : "w-[220px]"
+                  isFocused && (node.type === "project" ? "ring-indigo-400" : "ring-fuchsia-400"),
+                  node.type === "project" ? "w-[260px]" : "w-[240px]"
                 )}
                 style={{ left: node.x, top: node.y }}
               >
@@ -693,6 +675,34 @@ export function AskRelationshipCanvas({
                 </div>
                 {node.meta && (
                   <p className="mt-3 text-[11px] uppercase tracking-wide text-slate-400">{node.meta}</p>
+                )}
+                {node.type === "challenge" && node.asks && node.asks.length > 0 && (
+                  <div className="mt-4 space-y-2">
+                    <p className="text-[11px] uppercase tracking-wide text-slate-400">ASK associés</p>
+                    <div className="space-y-2">
+                      {node.asks.map(ask => {
+                        const isAskFocused = focusAskId === ask.id;
+                        return (
+                          <button
+                            key={ask.id}
+                            type="button"
+                            className={cn(
+                              "w-full rounded-2xl border border-white/10 bg-white/5 p-3 text-left transition",
+                              "hover:border-emerald-300/60 hover:bg-emerald-500/10",
+                              isAskFocused && "border-emerald-400 bg-emerald-500/20"
+                            )}
+                            onClick={event => {
+                              event.stopPropagation();
+                              onAskSelect?.(ask.id);
+                            }}
+                          >
+                            <p className="text-xs font-semibold text-white">{ask.title}</p>
+                            <p className="mt-1 line-clamp-2 text-[11px] text-slate-200/80">{ask.question}</p>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
                 )}
               </div>
             );
@@ -744,11 +754,7 @@ export function AskRelationshipCanvas({
                 key={`mini-${node.id}`}
                 className={cn(
                   "absolute rounded-lg",
-                  node.type === "project"
-                    ? "bg-indigo-400/50"
-                    : node.type === "challenge"
-                    ? "bg-fuchsia-400/60"
-                    : "bg-emerald-400/60"
+                  node.type === "project" ? "bg-indigo-400/50" : "bg-fuchsia-400/60"
                 )}
                 style={{
                   left: (node.x - minimap.offsetX) * minimap.scale,


### PR DESCRIPTION
## Summary
- embed ASK session summaries directly inside each challenge card on the relationship canvas
- remove standalone ASK nodes from the layout and size challenge nodes dynamically to fit their ASK lists
- keep focus, highlighting, and minimap behavior aligned with the challenge-centric view

## Testing
- npm run lint *(fails: command prompts for ESLint configuration and cannot run non-interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68dcc327a45c832aa063f451fdede8d8