### PR TITLE
Add popin detail dialogs for canvas interactions

### DIFF
--- a/src/components/admin/AskRelationshipCanvas.tsx
+++ b/src/components/admin/AskRelationshipCanvas.tsx
@@ -51,8 +51,7 @@ interface AskRelationshipCanvasProps {
   onProjectSelect?: (projectId: string) => void;
   onChallengeSelect?: (challengeId: string) => void;
   onAskSelect?: (askId: string) => void;
-
-
+}
 const PROJECT_NODE = { width: 260, height: 104 } as const;
 const CHALLENGE_NODE = { width: 240, height: 92 } as const;
 const ASK_NODE = { width: 220, height: 84 } as const;


### PR DESCRIPTION
## Summary
- add Radix dialog popins that show challenge and ASK details when nodes are clicked in the relationship canvas
- track the selected canvas entity to populate modal metadata and keep existing selection workflow
- restore the AskRelationshipCanvas props interface closure to keep the build passing

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dccaa82fd8832aa6040c494a750ba1