### PR TITLE
Handle case-insensitive ASK key lookups

### DIFF
--- a/src/app/api/ask/[key]/respond/route.ts
+++ b/src/app/api/ask/[key]/respond/route.ts
@@ -5,8 +5,7 @@ import { getAdminSupabaseClient } from '@/lib/supabaseAdmin';
 import { isValidAskKey, parseErrorMessage } from '@/lib/utils';
 import { INSIGHT_TYPES, mapInsightRowToInsight, type InsightRow } from '@/lib/insights';
 import { normaliseMessageMetadata } from '@/lib/messages';
-
-type AdminSupabaseClient = ReturnType<typeof getAdminSupabaseClient>;
+import { getAskSessionByKey } from '@/lib/asks';
 
 type AdminSupabaseClient = ReturnType<typeof getAdminSupabaseClient>;
 
@@ -282,11 +281,11 @@ export async function POST(
 
     const supabase = getAdminSupabaseClient();
 
-    const { data: askRow, error: askError } = await supabase
-      .from('ask_sessions')
-      .select('id, ask_key')
-      .eq('ask_key', key)
-      .maybeSingle<AskSessionRow>();
+    const { row: askRow, error: askError } = await getAskSessionByKey<AskSessionRow>(
+      supabase,
+      key,
+      'id, ask_key'
+    );
 
     if (askError) {
       throw askError;

--- a/src/app/api/ask/[key]/route.ts
+++ b/src/app/api/ask/[key]/route.ts
@@ -4,6 +4,7 @@ import { isValidAskKey, parseErrorMessage } from '@/lib/utils';
 import { getAdminSupabaseClient } from '@/lib/supabaseAdmin';
 import { mapInsightRowToInsight, type InsightRow } from '@/lib/insights';
 import { normaliseMessageMetadata } from '@/lib/messages';
+import { getAskSessionByKey } from '@/lib/asks';
 
 interface AskSessionRow {
   id: string;
@@ -89,11 +90,11 @@ export async function GET(
 
     const supabase = getAdminSupabaseClient();
 
-    const { data: askRow, error: askError } = await supabase
-      .from('ask_sessions')
-      .select('*')
-      .eq('ask_key', key)
-      .maybeSingle<AskSessionRow>();
+    const { row: askRow, error: askError } = await getAskSessionByKey<AskSessionRow>(
+      supabase,
+      key,
+      '*'
+    );
 
     if (askError) {
       throw askError;
@@ -327,11 +328,11 @@ export async function POST(
 
     const supabase = getAdminSupabaseClient();
 
-    const { data: askRow, error: askError } = await supabase
-      .from('ask_sessions')
-      .select('id, ask_key')
-      .eq('ask_key', key)
-      .maybeSingle<Pick<AskSessionRow, 'id' | 'ask_key'>>();
+    const { row: askRow, error: askError } = await getAskSessionByKey<Pick<AskSessionRow, 'id' | 'ask_key'>>(
+      supabase,
+      key,
+      'id, ask_key'
+    );
 
     if (askError) {
       throw askError;

--- a/src/lib/asks.ts
+++ b/src/lib/asks.ts
@@ -1,0 +1,46 @@
+import type { PostgrestError, SupabaseClient } from '@supabase/supabase-js';
+
+function escapeIlikePattern(value: string): string {
+  return value.replace(/([%_\\])/g, '\\$1');
+}
+
+export async function getAskSessionByKey<Row>(
+  supabase: SupabaseClient,
+  rawKey: string,
+  columns: string
+): Promise<{ row: Row | null; error: PostgrestError | null }> {
+  const key = rawKey.trim();
+
+  const { data, error } = await supabase
+    .from('ask_sessions')
+    .select(columns)
+    .eq('ask_key', key)
+    .maybeSingle<Row>();
+
+  if (error) {
+    return { row: null, error };
+  }
+
+  if (data) {
+    return { row: data, error: null };
+  }
+
+  const fallbackPattern = escapeIlikePattern(key);
+
+  const { data: fallbackRows, error: fallbackError } = await supabase
+    .from('ask_sessions')
+    .select(columns)
+    .ilike('ask_key', fallbackPattern)
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  if (fallbackError) {
+    return { row: null, error: fallbackError };
+  }
+
+  const fallbackRow = Array.isArray(fallbackRows) && fallbackRows.length > 0
+    ? (fallbackRows[0] as Row)
+    : null;
+
+  return { row: fallbackRow ?? null, error: null };
+}


### PR DESCRIPTION
## Summary
- add a reusable Supabase helper that trims ASK keys and retries with a case-insensitive match
- switch the ASK data and response endpoints to use the helper so existing sessions resolve even when the URL casing differs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68decfe1982c832aa7df89d7bf4baa6c