### PR TITLE
Add generated ask_id alias for insights

### DIFF
--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -124,6 +124,7 @@ CREATE TABLE messages (
 CREATE TABLE insights (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     ask_session_id UUID NOT NULL REFERENCES ask_sessions(id) ON DELETE CASCADE,
+    ask_id UUID GENERATED ALWAYS AS (ask_session_id) STORED,
     user_id UUID REFERENCES users(id) ON DELETE SET NULL,
     challenge_id UUID REFERENCES challenges(id) ON DELETE SET NULL,
     content TEXT NOT NULL,
@@ -179,6 +180,7 @@ CREATE INDEX idx_ask_sessions_status ON ask_sessions(status);
 CREATE INDEX idx_messages_ask_session_id ON messages(ask_session_id);
 CREATE INDEX idx_messages_created_at ON messages(created_at);
 CREATE INDEX idx_insights_ask_session_id ON insights(ask_session_id);
+CREATE INDEX idx_insights_ask_id ON insights(ask_id);
 CREATE INDEX idx_insights_challenge_id ON insights(challenge_id);
 CREATE INDEX idx_insights_type ON insights(insight_type);
 CREATE INDEX idx_kpi_estimations_insight_id ON kpi_estimations(insight_id);

--- a/migrations/003_add_insight_ask_id_alias.sql
+++ b/migrations/003_add_insight_ask_id_alias.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+ALTER TABLE public.insights
+  ADD COLUMN IF NOT EXISTS ask_id UUID GENERATED ALWAYS AS (ask_session_id) STORED;
+
+CREATE INDEX IF NOT EXISTS insights_ask_id_idx
+  ON public.insights (ask_id);
+
+COMMIT;
+
+-- //@UNDO
+BEGIN;
+
+ALTER TABLE public.insights
+  DROP COLUMN IF EXISTS ask_id;
+
+COMMIT;

--- a/src/lib/insights.ts
+++ b/src/lib/insights.ts
@@ -11,6 +11,7 @@ export interface InsightAuthorRow {
 export interface InsightRow {
   id: string;
   ask_session_id: string;
+  ask_id?: string | null;
   challenge_id?: string | null;
   content?: string | null;
   summary?: string | null;
@@ -40,8 +41,8 @@ export function mapInsightRowToInsight(row: InsightRow): Insight {
 
   return {
     id: row.id,
-    askId: row.ask_session_id,
-    askSessionId: row.ask_session_id,
+    askId: row.ask_session_id ?? row.ask_id ?? '',
+    askSessionId: row.ask_session_id ?? row.ask_id ?? '',
     challengeId: row.challenge_id ?? null,
     authorId: primaryAuthor?.userId ?? null,
     authorName: primaryAuthor?.name ?? null,


### PR DESCRIPTION
## Summary
- add a generated `ask_id` column to the `insights` table via migration to mirror `ask_session_id`
- document the new alias column and index in DATABASE_SETUP
- allow insight row mapping to read from either `ask_session_id` or the new alias

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dedbd8bcc4832a98bf2970e7027f94