### PR TITLE
Handle missing ask_id in Supabase insight fallbacks

### DIFF
--- a/src/app/api/ask/[key]/respond/route.ts
+++ b/src/app/api/ask/[key]/respond/route.ts
@@ -553,8 +553,9 @@ export async function POST(
           .select('id, ask_session_id, challenge_id, content, summary, type, category, status, priority, created_at, updated_at, related_challenge_ids, kpis, source_message_id, insight_authors (id, user_id, display_name)')
           .eq('ask_session_id', askRow.id)
           .order('created_at', { ascending: true });
-        
-        latestInsights = fallbackResult.data;
+
+        // Normalise results from legacy schemas without ask_id
+        latestInsights = fallbackResult.data?.map((row) => ({ ...row, ask_id: null })) ?? null;
         latestError = fallbackResult.error;
       }
 

--- a/src/app/api/ask/[key]/route.ts
+++ b/src/app/api/ask/[key]/route.ts
@@ -243,8 +243,9 @@ export async function GET(
         .select('id, ask_session_id, challenge_id, content, summary, type, category, status, priority, created_at, updated_at, related_challenge_ids, kpis, source_message_id, insight_authors (id, user_id, display_name)')
         .eq('ask_session_id', askSessionId)
         .order('created_at', { ascending: true });
-      
-      insightRows = fallbackResult.data;
+
+      // Normalise legacy results without ask_id
+      insightRows = fallbackResult.data?.map((row) => ({ ...row, ask_id: null })) ?? null;
       insightError = fallbackResult.error;
     }
 


### PR DESCRIPTION
## Summary
- normalize fallback Supabase insight queries to include a null ask_id when the column is absent
- ensure both ask retrieval endpoints maintain consistent typing for legacy insight records

## Testing
- npm run vercel-build

------
https://chatgpt.com/codex/tasks/task_e_68dee54f8914832a85c381608832d0b4