### PR TITLE
Replace webhook orchestration with internal AI controller

### DIFF
--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -306,9 +306,17 @@ POSTGRES_PASSWORD=super-secret-password
 POSTGRES_HOST=db.supabase.co
 POSTGRES_DATABASE=postgres
 
-# n8n Webhook
-EXTERNAL_RESPONSE_WEBHOOK=your-n8n-webhook-url
+# AI providers
+ANTHROPIC_API_KEY=sk-ant-...
+MISTRAL_API_KEY=sk-mistral-...
 ```
+
+### Nouvelles tables IA à vérifier
+
+- `ai_model_configs` : configuration des fournisseurs (code, modèle, URL, variable d'environnement).
+- `ai_agents` : prompts `system`/`user`, modèles associés et variables autorisées.
+- `ai_agent_logs` : journal des requêtes et réponses IA.
+- `ai_insight_jobs` : file d'attente pour la détection séquentielle des insights.
 
 
 ## Post-migration validation for ASK sessions

--- a/migrations/003_ai_controller.sql
+++ b/migrations/003_ai_controller.sql
@@ -1,0 +1,107 @@
+BEGIN;
+
+-- Drop legacy n8n tables
+DROP TABLE IF EXISTS public.n8n_chat_histories CASCADE;
+DROP SEQUENCE IF EXISTS public.n8n_chat_histories_id_seq;
+
+-- Extend core domain objects with system prompt overrides
+ALTER TABLE public.projects
+  ADD COLUMN IF NOT EXISTS system_prompt TEXT;
+
+ALTER TABLE public.challenges
+  ADD COLUMN IF NOT EXISTS system_prompt TEXT;
+
+ALTER TABLE public.ask_sessions
+  ADD COLUMN IF NOT EXISTS system_prompt TEXT;
+
+-- Model configuration table to describe available providers
+CREATE TABLE IF NOT EXISTS public.ai_model_configs (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  code VARCHAR NOT NULL UNIQUE,
+  name VARCHAR NOT NULL,
+  provider VARCHAR NOT NULL,
+  model VARCHAR NOT NULL,
+  base_url TEXT,
+  api_key_env_var VARCHAR NOT NULL,
+  additional_headers JSONB,
+  is_default BOOLEAN DEFAULT false,
+  is_fallback BOOLEAN DEFAULT false,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Agent definitions with prompts and template metadata
+CREATE TABLE IF NOT EXISTS public.ai_agents (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  slug VARCHAR NOT NULL UNIQUE,
+  name VARCHAR NOT NULL,
+  description TEXT,
+  model_config_id UUID REFERENCES public.ai_model_configs(id) ON DELETE SET NULL,
+  fallback_model_config_id UUID REFERENCES public.ai_model_configs(id) ON DELETE SET NULL,
+  system_prompt TEXT NOT NULL,
+  user_prompt TEXT NOT NULL,
+  available_variables TEXT[] DEFAULT '{}'::TEXT[],
+  metadata JSONB,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Logs to keep track of each request/response with an AI provider
+CREATE TABLE IF NOT EXISTS public.ai_agent_logs (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  agent_id UUID REFERENCES public.ai_agents(id) ON DELETE SET NULL,
+  model_config_id UUID REFERENCES public.ai_model_configs(id) ON DELETE SET NULL,
+  ask_session_id UUID REFERENCES public.ask_sessions(id) ON DELETE SET NULL,
+  message_id UUID REFERENCES public.messages(id) ON DELETE SET NULL,
+  interaction_type VARCHAR NOT NULL,
+  request_payload JSONB NOT NULL,
+  response_payload JSONB,
+  status VARCHAR NOT NULL DEFAULT 'pending',
+  error_message TEXT,
+  latency_ms INTEGER,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS ai_agent_logs_agent_id_idx
+  ON public.ai_agent_logs (agent_id);
+
+CREATE INDEX IF NOT EXISTS ai_agent_logs_ask_session_id_idx
+  ON public.ai_agent_logs (ask_session_id);
+
+-- Insight detection job queue to avoid concurrent processing
+CREATE TABLE IF NOT EXISTS public.ai_insight_jobs (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  ask_session_id UUID NOT NULL REFERENCES public.ask_sessions(id) ON DELETE CASCADE,
+  message_id UUID REFERENCES public.messages(id) ON DELETE SET NULL,
+  agent_id UUID REFERENCES public.ai_agents(id) ON DELETE SET NULL,
+  model_config_id UUID REFERENCES public.ai_model_configs(id) ON DELETE SET NULL,
+  status VARCHAR NOT NULL DEFAULT 'pending',
+  attempts INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  started_at TIMESTAMPTZ,
+  finished_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ai_insight_jobs_active_session_idx
+  ON public.ai_insight_jobs (ask_session_id)
+  WHERE status IN ('pending', 'processing');
+
+COMMIT;
+
+-- //@UNDO
+BEGIN;
+
+DROP INDEX IF EXISTS ai_insight_jobs_active_session_idx;
+DROP TABLE IF EXISTS public.ai_insight_jobs CASCADE;
+DROP INDEX IF EXISTS ai_agent_logs_ask_session_id_idx;
+DROP INDEX IF EXISTS ai_agent_logs_agent_id_idx;
+DROP TABLE IF EXISTS public.ai_agent_logs CASCADE;
+DROP TABLE IF EXISTS public.ai_agents CASCADE;
+DROP TABLE IF EXISTS public.ai_model_configs CASCADE;
+ALTER TABLE public.ask_sessions DROP COLUMN IF EXISTS system_prompt;
+ALTER TABLE public.challenges DROP COLUMN IF EXISTS system_prompt;
+ALTER TABLE public.projects DROP COLUMN IF EXISTS system_prompt;
+
+COMMIT;

--- a/src/app/admin/ai/logs/page.tsx
+++ b/src/app/admin/ai/logs/page.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { AiAgentLog } from "@/types";
+
+interface LogsResponse {
+  success: boolean;
+  data?: AiAgentLog[];
+  error?: string;
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat("fr-FR", {
+    dateStyle: "short",
+    timeStyle: "medium",
+  }).format(date);
+}
+
+export default function AiLogsPage() {
+  const [logs, setLogs] = useState<AiAgentLog[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadLogs = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/admin/ai/logs?limit=100");
+      const json: LogsResponse = await response.json();
+
+      if (!json.success) {
+        throw new Error(json.error || "Impossible de récupérer les logs");
+      }
+
+      setLogs(json.data ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erreur inattendue lors du chargement");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadLogs();
+  }, []);
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Historique des requêtes IA</h1>
+          <p className="text-muted-foreground">Visualisez les appels envoyés aux modèles et leurs réponses.</p>
+        </div>
+        <Button onClick={loadLogs} disabled={isLoading}>
+          Rafraîchir
+        </Button>
+      </div>
+
+      {error && (
+        <Card className="border-destructive/40">
+          <CardHeader>
+            <CardTitle className="text-destructive text-base">Erreur</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p>{error}</p>
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="grid gap-4">
+        {isLoading && logs.length === 0 ? (
+          <p className="text-muted-foreground">Chargement des logs...</p>
+        ) : logs.length === 0 ? (
+          <p className="text-muted-foreground">Aucun log récent.</p>
+        ) : (
+          logs.map(log => (
+            <Card key={log.id} className="border-muted/60">
+              <CardHeader className="flex flex-col gap-1">
+                <CardTitle className="text-base font-semibold">
+                  {log.interactionType}
+                </CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  Agent ID: {log.agentId ?? "n/a"} · Modèle: {log.modelConfigId ?? "n/a"}
+                </p>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm">
+                <div className="grid gap-1 md:grid-cols-2">
+                  <p><span className="font-medium">Session:</span> {log.askSessionId ?? "-"}</p>
+                  <p><span className="font-medium">Message:</span> {log.messageId ?? "-"}</p>
+                  <p><span className="font-medium">Statut:</span> {log.status}</p>
+                  <p><span className="font-medium">Durée:</span> {log.latencyMs ? `${log.latencyMs} ms` : "-"}</p>
+                  <p><span className="font-medium">Créé le:</span> {formatDate(log.createdAt)}</p>
+                </div>
+
+                <details className="rounded border bg-muted/40 p-3">
+                  <summary className="cursor-pointer font-medium">Payload envoyé</summary>
+                  <pre className="mt-2 whitespace-pre-wrap text-xs">
+                    {JSON.stringify(log.requestPayload, null, 2)}
+                  </pre>
+                </details>
+
+                {log.responsePayload && (
+                  <details className="rounded border bg-muted/40 p-3">
+                    <summary className="cursor-pointer font-medium">Réponse</summary>
+                    <pre className="mt-2 whitespace-pre-wrap text-xs">
+                      {JSON.stringify(log.responsePayload, null, 2)}
+                    </pre>
+                  </details>
+                )}
+
+                {log.errorMessage && (
+                  <div className="rounded border border-destructive/40 bg-destructive/5 p-3 text-destructive">
+                    {log.errorMessage}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/ai/page.tsx
+++ b/src/app/admin/ai/page.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import type { AiAgentRecord, AiModelConfig, PromptVariableDefinition } from "@/types";
+
+interface AgentsResponse {
+  success: boolean;
+  data?: {
+    agents: AiAgentRecord[];
+    variables: PromptVariableDefinition[];
+  };
+  error?: string;
+}
+
+interface ModelsResponse {
+  success: boolean;
+  data?: AiModelConfig[];
+  error?: string;
+}
+
+type AgentDraft = AiAgentRecord & {
+  systemPromptDraft: string;
+  userPromptDraft: string;
+  availableVariablesDraft: string[];
+  modelConfigIdDraft: string | null;
+  fallbackModelConfigIdDraft: string | null;
+  isSaving?: boolean;
+  saveError?: string | null;
+  saveSuccess?: boolean;
+};
+
+function mergeAgentWithDraft(agent: AiAgentRecord): AgentDraft {
+  return {
+    ...agent,
+    systemPromptDraft: agent.systemPrompt,
+    userPromptDraft: agent.userPrompt,
+    availableVariablesDraft: [...agent.availableVariables],
+    modelConfigIdDraft: agent.modelConfigId ?? null,
+    fallbackModelConfigIdDraft: agent.fallbackModelConfigId ?? null,
+    isSaving: false,
+    saveError: null,
+    saveSuccess: false,
+  };
+}
+
+export default function AiConfigurationPage() {
+  const [agents, setAgents] = useState<AgentDraft[]>([]);
+  const [models, setModels] = useState<AiModelConfig[]>([]);
+  const [variables, setVariables] = useState<PromptVariableDefinition[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchConfiguration = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const [agentsResponse, modelsResponse] = await Promise.all([
+        fetch("/api/admin/ai/agents"),
+        fetch("/api/admin/ai/models"),
+      ]);
+
+      const agentsJson: AgentsResponse = await agentsResponse.json();
+      const modelsJson: ModelsResponse = await modelsResponse.json();
+
+      if (!agentsJson.success) {
+        throw new Error(agentsJson.error || "Impossible de charger les agents");
+      }
+      if (!modelsJson.success) {
+        throw new Error(modelsJson.error || "Impossible de charger les modèles");
+      }
+
+      setAgents(agentsJson.data?.agents.map(mergeAgentWithDraft) ?? []);
+      setVariables(agentsJson.data?.variables ?? []);
+      setModels(modelsJson.data ?? []);
+    } catch (err) {
+      console.error(err);
+      setError(err instanceof Error ? err.message : "Erreur inattendue lors du chargement");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchConfiguration();
+  }, []);
+
+  const handleToggleVariable = (agentId: string, variable: string) => {
+    setAgents(prev => prev.map(agent => {
+      if (agent.id !== agentId) {
+        return agent;
+      }
+      const exists = agent.availableVariablesDraft.includes(variable);
+      const updatedVariables = exists
+        ? agent.availableVariablesDraft.filter(item => item !== variable)
+        : [...agent.availableVariablesDraft, variable];
+      return { ...agent, availableVariablesDraft: updatedVariables, saveSuccess: false };
+    }));
+  };
+
+  const handlePromptChange = (agentId: string, field: "system" | "user", value: string) => {
+    setAgents(prev => prev.map(agent => {
+      if (agent.id !== agentId) {
+        return agent;
+      }
+      if (field === "system") {
+        return { ...agent, systemPromptDraft: value, saveSuccess: false };
+      }
+      return { ...agent, userPromptDraft: value, saveSuccess: false };
+    }));
+  };
+
+  const handleModelChange = (agentId: string, field: "primary" | "fallback", value: string) => {
+    setAgents(prev => prev.map(agent => {
+      if (agent.id !== agentId) {
+        return agent;
+      }
+      if (field === "primary") {
+        return { ...agent, modelConfigIdDraft: value || null, saveSuccess: false };
+      }
+      return { ...agent, fallbackModelConfigIdDraft: value || null, saveSuccess: false };
+    }));
+  };
+
+  const handleSaveAgent = async (agentId: string) => {
+    setAgents(prev => prev.map(agent => agent.id === agentId ? { ...agent, isSaving: true, saveError: null, saveSuccess: false } : agent));
+
+    const agent = agents.find(item => item.id === agentId);
+    if (!agent) {
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/admin/ai/agents/${agentId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          systemPrompt: agent.systemPromptDraft,
+          userPrompt: agent.userPromptDraft,
+          availableVariables: agent.availableVariablesDraft,
+          modelConfigId: agent.modelConfigIdDraft,
+          fallbackModelConfigId: agent.fallbackModelConfigIdDraft,
+        }),
+      });
+
+      const result = await response.json();
+
+      if (!result.success) {
+        throw new Error(result.error || "Impossible d'enregistrer l'agent");
+      }
+
+      setAgents(prev => prev.map(item => {
+        if (item.id !== agentId) {
+          return item;
+        }
+        return {
+          ...item,
+          systemPrompt: item.systemPromptDraft,
+          userPrompt: item.userPromptDraft,
+          availableVariables: [...item.availableVariablesDraft],
+          modelConfigId: item.modelConfigIdDraft,
+          fallbackModelConfigId: item.fallbackModelConfigIdDraft,
+          isSaving: false,
+          saveSuccess: true,
+        };
+      }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Erreur lors de l'enregistrement";
+      setAgents(prev => prev.map(item => item.id === agentId ? { ...item, isSaving: false, saveError: message } : item));
+    }
+  };
+
+  const sortedVariables = useMemo(() => {
+    return [...variables].sort((a, b) => a.key.localeCompare(b.key));
+  }, [variables]);
+
+  return (
+    <div className="p-6 space-y-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Configuration des agents IA</h1>
+          <p className="text-muted-foreground">Gérez les prompts et l'association aux modèles.</p>
+        </div>
+        <Button onClick={fetchConfiguration} disabled={isLoading}>
+          Rafraîchir
+        </Button>
+      </div>
+
+      {error && (
+        <Card className="border-destructive/40">
+          <CardHeader>
+            <CardTitle className="text-destructive">Erreur de chargement</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p>{error}</p>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Variables disponibles</CardTitle>
+          <CardDescription>Insérez ces variables dans vos prompts via la syntaxe {{variable}}.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-2">
+          {sortedVariables.map(variable => (
+            <div key={variable.key} className="rounded-lg border p-4 bg-muted/30">
+              <p className="font-semibold">{variable.key}</p>
+              <p className="text-sm text-muted-foreground">{variable.description}</p>
+              {variable.example && (
+                <p className="text-xs text-muted-foreground mt-2">Exemple : {variable.example}</p>
+              )}
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6">
+        {isLoading && agents.length === 0 ? (
+          <p className="text-muted-foreground">Chargement des agents...</p>
+        ) : agents.length === 0 ? (
+          <p className="text-muted-foreground">Aucun agent configuré pour le moment.</p>
+        ) : (
+          agents.map(agent => (
+            <Card key={agent.id} className="border-primary/10">
+              <CardHeader>
+                <CardTitle>{agent.name}</CardTitle>
+                {agent.description && <CardDescription>{agent.description}</CardDescription>}
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label>Modèle principal</Label>
+                    <select
+                      className="w-full rounded border border-input bg-background px-3 py-2 text-sm"
+                      value={agent.modelConfigIdDraft ?? ''}
+                      onChange={event => handleModelChange(agent.id, "primary", event.target.value)}
+                    >
+                      <option value="">Aucun</option>
+                      {models.map(model => (
+                        <option key={model.id} value={model.id}>
+                          {model.name} — {model.model}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Modèle de secours</Label>
+                    <select
+                      className="w-full rounded border border-input bg-background px-3 py-2 text-sm"
+                      value={agent.fallbackModelConfigIdDraft ?? ''}
+                      onChange={event => handleModelChange(agent.id, "fallback", event.target.value)}
+                    >
+                      <option value="">Aucun</option>
+                      {models.map(model => (
+                        <option key={model.id} value={model.id}>
+                          {model.name} — {model.model}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor={`system-${agent.id}`}>System prompt</Label>
+                    <Textarea
+                      id={`system-${agent.id}`}
+                      value={agent.systemPromptDraft}
+                      onChange={event => handlePromptChange(agent.id, "system", event.target.value)}
+                      rows={8}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor={`user-${agent.id}`}>User prompt</Label>
+                    <Textarea
+                      id={`user-${agent.id}`}
+                      value={agent.userPromptDraft}
+                      onChange={event => handlePromptChange(agent.id, "user", event.target.value)}
+                      rows={8}
+                    />
+                  </div>
+                </div>
+
+                <div className="space-y-3">
+                  <Label>Variables actives</Label>
+                  <div className="flex flex-wrap gap-2">
+                    {sortedVariables.map(variable => {
+                      const isActive = agent.availableVariablesDraft.includes(variable.key);
+                      return (
+                        <button
+                          key={variable.key}
+                          type="button"
+                          onClick={() => handleToggleVariable(agent.id, variable.key)}
+                          className={`px-3 py-1 text-sm rounded-full border transition ${isActive ? 'bg-primary text-primary-foreground border-primary' : 'bg-muted border-muted-foreground/20'}`}
+                        >
+                          {variable.key}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {agent.saveError && (
+                  <p className="text-sm text-destructive">{agent.saveError}</p>
+                )}
+                {agent.saveSuccess && (
+                  <p className="text-sm text-emerald-600">Modifications enregistrées.</p>
+                )}
+
+                <Button
+                  onClick={() => handleSaveAgent(agent.id)}
+                  disabled={agent.isSaving}
+                >
+                  {agent.isSaving ? 'Enregistrement...' : 'Enregistrer'}
+                </Button>
+              </CardContent>
+            </Card>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/ai/page.tsx
+++ b/src/app/admin/ai/page.tsx
@@ -203,7 +203,9 @@ export default function AiConfigurationPage() {
       <Card>
         <CardHeader>
           <CardTitle>Variables disponibles</CardTitle>
-          <CardDescription>Insérez ces variables dans vos prompts via la syntaxe {{variable}}.</CardDescription>
+          <CardDescription>
+            Insérez ces variables dans vos prompts via la syntaxe {"{{variable}}"}.
+          </CardDescription>
         </CardHeader>
         <CardContent className="grid gap-4 md:grid-cols-2">
           {sortedVariables.map(variable => (

--- a/src/app/api/admin/ai/agents/[id]/route.ts
+++ b/src/app/api/admin/ai/agents/[id]/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminSupabaseClient } from '@/lib/supabaseAdmin';
+import { parseErrorMessage } from '@/lib/utils';
+
+interface AgentUpdatePayload {
+  name?: string;
+  description?: string | null;
+  systemPrompt?: string;
+  userPrompt?: string;
+  modelConfigId?: string | null;
+  fallbackModelConfigId?: string | null;
+  availableVariables?: string[];
+}
+
+function sanitizeVariables(values: unknown): string[] | undefined {
+  if (!Array.isArray(values)) {
+    return undefined;
+  }
+
+  return values
+    .map(value => (typeof value === 'string' ? value.trim() : ''))
+    .filter(value => value.length > 0);
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const { id } = params;
+    const body = (await request.json()) as AgentUpdatePayload;
+
+    const supabase = getAdminSupabaseClient();
+
+    const updatePayload: Record<string, unknown> = {};
+
+    if (typeof body.name === 'string' && body.name.trim().length > 0) {
+      updatePayload.name = body.name.trim();
+    }
+    if (typeof body.description === 'string' || body.description === null) {
+      updatePayload.description = body.description ?? null;
+    }
+    if (typeof body.systemPrompt === 'string') {
+      updatePayload.system_prompt = body.systemPrompt;
+    }
+    if (typeof body.userPrompt === 'string') {
+      updatePayload.user_prompt = body.userPrompt;
+    }
+    if (body.modelConfigId === null || typeof body.modelConfigId === 'string') {
+      updatePayload.model_config_id = body.modelConfigId ?? null;
+    }
+    if (body.fallbackModelConfigId === null || typeof body.fallbackModelConfigId === 'string') {
+      updatePayload.fallback_model_config_id = body.fallbackModelConfigId ?? null;
+    }
+
+    const variables = sanitizeVariables(body.availableVariables);
+    if (variables) {
+      updatePayload.available_variables = variables;
+    }
+
+    if (Object.keys(updatePayload).length === 0) {
+      return NextResponse.json({
+        success: false,
+        error: 'No valid fields provided for update',
+      }, { status: 400 });
+    }
+
+    const { data, error } = await supabase
+      .from('ai_agents')
+      .update(updatePayload)
+      .eq('id', id)
+      .select('*')
+      .maybeSingle();
+
+    if (error) {
+      throw error;
+    }
+
+    return NextResponse.json({
+      success: true,
+      data,
+      message: 'Agent mis à jour',
+    });
+  } catch (error) {
+    console.error('Unable to update AI agent', error);
+    return NextResponse.json({
+      success: false,
+      error: parseErrorMessage(error),
+    }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/ai/agents/route.ts
+++ b/src/app/api/admin/ai/agents/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { getAdminSupabaseClient } from '@/lib/supabaseAdmin';
+import { listAgents } from '@/lib/ai/agents';
+import { PROMPT_VARIABLES } from '@/lib/ai/constants';
+
+export async function GET() {
+  try {
+    const supabase = getAdminSupabaseClient();
+    const agents = await listAgents(supabase, { includeModels: true });
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        agents,
+        variables: PROMPT_VARIABLES,
+      },
+    });
+  } catch (error) {
+    console.error('Unable to list AI agents', error);
+    return NextResponse.json({
+      success: false,
+      error: (error instanceof Error ? error.message : 'Unexpected error while loading AI agents'),
+    }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/ai/logs/route.ts
+++ b/src/app/api/admin/ai/logs/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminSupabaseClient } from '@/lib/supabaseAdmin';
+import { listAgentLogs } from '@/lib/ai/logs';
+import { parseErrorMessage } from '@/lib/utils';
+
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = getAdminSupabaseClient();
+    const { searchParams } = new URL(request.url);
+    const limitParam = searchParams.get('limit');
+    const limit = limitParam ? Math.max(1, Math.min(200, Number(limitParam))) : 100;
+
+    const logs = await listAgentLogs(supabase, { limit });
+
+    return NextResponse.json({
+      success: true,
+      data: logs,
+    });
+  } catch (error) {
+    console.error('Unable to list AI agent logs', error);
+    return NextResponse.json({
+      success: false,
+      error: parseErrorMessage(error),
+    }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/ai/models/[id]/route.ts
+++ b/src/app/api/admin/ai/models/[id]/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminSupabaseClient } from '@/lib/supabaseAdmin';
+import { parseErrorMessage } from '@/lib/utils';
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const { id } = params;
+    const body = await request.json();
+    const supabase = getAdminSupabaseClient();
+
+    const payload: Record<string, unknown> = {};
+
+    if (typeof body.code === 'string') {
+      payload.code = body.code.trim();
+    }
+    if (typeof body.name === 'string') {
+      payload.name = body.name.trim();
+    }
+    if (typeof body.provider === 'string') {
+      payload.provider = body.provider.trim();
+    }
+    if (typeof body.model === 'string') {
+      payload.model = body.model.trim();
+    }
+    if (typeof body.baseUrl === 'string' || body.baseUrl === null) {
+      payload.base_url = body.baseUrl ?? null;
+    }
+    if (typeof body.apiKeyEnvVar === 'string') {
+      payload.api_key_env_var = body.apiKeyEnvVar.trim();
+    }
+    if (body.additionalHeaders && typeof body.additionalHeaders === 'object') {
+      payload.additional_headers = body.additionalHeaders;
+    }
+    if (typeof body.isDefault === 'boolean') {
+      payload.is_default = body.isDefault;
+    }
+    if (typeof body.isFallback === 'boolean') {
+      payload.is_fallback = body.isFallback;
+    }
+
+    if (Object.keys(payload).length === 0) {
+      return NextResponse.json({
+        success: false,
+        error: 'No valid fields provided',
+      }, { status: 400 });
+    }
+
+    const { data, error } = await supabase
+      .from('ai_model_configs')
+      .update(payload)
+      .eq('id', id)
+      .select('*')
+      .maybeSingle();
+
+    if (error) {
+      throw error;
+    }
+
+    return NextResponse.json({
+      success: true,
+      data,
+      message: 'Modèle IA mis à jour',
+    });
+  } catch (error) {
+    console.error('Unable to update AI model configuration', error);
+    return NextResponse.json({
+      success: false,
+      error: parseErrorMessage(error),
+    }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/ai/models/route.ts
+++ b/src/app/api/admin/ai/models/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminSupabaseClient } from '@/lib/supabaseAdmin';
+import { listModelConfigs } from '@/lib/ai/models';
+import { parseErrorMessage } from '@/lib/utils';
+
+export async function GET() {
+  try {
+    const supabase = getAdminSupabaseClient();
+    const models = await listModelConfigs(supabase);
+
+    return NextResponse.json({
+      success: true,
+      data: models,
+    });
+  } catch (error) {
+    console.error('Unable to load AI model configurations', error);
+    return NextResponse.json({
+      success: false,
+      error: parseErrorMessage(error),
+    }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = getAdminSupabaseClient();
+    const body = await request.json();
+
+    const payload: Record<string, unknown> = {
+      code: typeof body.code === 'string' ? body.code.trim() : null,
+      name: typeof body.name === 'string' ? body.name.trim() : null,
+      provider: typeof body.provider === 'string' ? body.provider.trim() : null,
+      model: typeof body.model === 'string' ? body.model.trim() : null,
+      base_url: typeof body.baseUrl === 'string' ? body.baseUrl.trim() : null,
+      api_key_env_var: typeof body.apiKeyEnvVar === 'string' ? body.apiKeyEnvVar.trim() : null,
+      additional_headers: body.additionalHeaders && typeof body.additionalHeaders === 'object' ? body.additionalHeaders : null,
+      is_default: Boolean(body.isDefault),
+      is_fallback: Boolean(body.isFallback),
+    };
+
+    if (!payload.code || !payload.name || !payload.provider || !payload.model || !payload.api_key_env_var) {
+      return NextResponse.json({
+        success: false,
+        error: 'code, name, provider, model et apiKeyEnvVar sont requis'
+      }, { status: 400 });
+    }
+
+    const { data, error } = await supabase
+      .from('ai_model_configs')
+      .insert(payload)
+      .select('*')
+      .maybeSingle();
+
+    if (error) {
+      throw error;
+    }
+
+    return NextResponse.json({
+      success: true,
+      data,
+      message: 'Modèle IA créé',
+    }, { status: 201 });
+  } catch (error) {
+    console.error('Unable to create AI model configuration', error);
+    return NextResponse.json({
+      success: false,
+      error: parseErrorMessage(error),
+    }, { status: 500 });
+  }
+}

--- a/src/app/api/challenges/[key]/route.ts
+++ b/src/app/api/challenges/[key]/route.ts
@@ -1,10 +1,55 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { ApiResponse, Challenge } from '@/types';
 import { isValidAskKey, parseErrorMessage } from '@/lib/utils';
+import { getAdminSupabaseClient } from '@/lib/supabaseAdmin';
+import { getAskSessionByKey } from '@/lib/asks';
+
+interface AskSessionRow {
+  id: string;
+  challenge_id?: string | null;
+}
+
+type ChallengeUpdatePayload = Partial<Pick<Challenge, 'name' | 'updatedAt'>> & {
+  description?: string | null;
+  status?: string | null;
+  priority?: string | null;
+  category?: string | null;
+  dueDate?: string | null;
+  assignedTo?: string | null;
+};
+
+function buildChallengeUpdate(data: ChallengeUpdatePayload) {
+  const payload: Record<string, unknown> = {};
+
+  if (typeof data.name === 'string') {
+    payload.name = data.name;
+  }
+  if (typeof data.description === 'string' || data.description === null) {
+    payload.description = data.description;
+  }
+  if (typeof data.status === 'string') {
+    payload.status = data.status;
+  }
+  if (typeof data.priority === 'string') {
+    payload.priority = data.priority;
+  }
+  if (typeof data.category === 'string' || data.category === null) {
+    payload.category = data.category;
+  }
+  if (typeof data.dueDate === 'string' || data.dueDate === null) {
+    payload.due_date = data.dueDate;
+  }
+  if (typeof data.assignedTo === 'string' || data.assignedTo === null) {
+    payload.assigned_to = data.assignedTo;
+  }
+
+  payload.updated_at = new Date().toISOString();
+
+  return payload;
+}
 
 /**
- * PUT /api/challenges/[key] - Update a single challenge via external backend
- * This endpoint forwards challenge updates to the external backend
+ * PUT /api/challenges/[key] - Update challenge linked to an ASK without external webhooks
  */
 export async function PUT(
   request: NextRequest,
@@ -20,46 +65,55 @@ export async function PUT(
       }, { status: 400 });
     }
 
-    const updateData = await request.json();
+    const body = (await request.json()) as ChallengeUpdatePayload;
 
-    const externalWebhook = process.env.EXTERNAL_RESPONSE_WEBHOOK;
-    
-    if (!externalWebhook) {
+    const supabase = getAdminSupabaseClient();
+
+    const { row: askRow, error: askError } = await getAskSessionByKey<AskSessionRow>(
+      supabase,
+      key,
+      'id, challenge_id'
+    );
+
+    if (askError) {
+      throw askError;
+    }
+
+    if (!askRow || !askRow.challenge_id) {
       return NextResponse.json<ApiResponse>({
         success: false,
-        error: 'External webhook not configured'
-      }, { status: 500 });
+        error: 'Aucun challenge associé à cette ASK'
+      }, { status: 404 });
     }
 
-    // Forward challenge update to external backend
-    const response = await fetch(externalWebhook, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Webhook-Source': 'agentic-design-flow',
-        'X-Request-Type': 'challenge-update'
-      },
-      body: JSON.stringify({
-        askKey: key,
-        action: 'update_challenge',
-        ...updateData
-      })
-    });
+    const updatePayload = buildChallengeUpdate(body);
 
-    if (!response.ok) {
-      throw new Error(`External webhook responded with status ${response.status}`);
+    if (Object.keys(updatePayload).length === 0) {
+      return NextResponse.json<ApiResponse>({
+        success: false,
+        error: 'Aucune donnée valide fournie pour la mise à jour'
+      }, { status: 400 });
     }
 
-    const result = await response.json();
+    const { data, error } = await supabase
+      .from('challenges')
+      .update(updatePayload)
+      .eq('id', askRow.challenge_id)
+      .select('id, name, description, status, priority, category, due_date, assigned_to, updated_at')
+      .maybeSingle();
+
+    if (error) {
+      throw error;
+    }
 
     return NextResponse.json<ApiResponse>({
       success: true,
-      data: result,
-      message: 'Challenge updated successfully'
+      data,
+      message: 'Challenge mis à jour avec succès'
     });
 
   } catch (error) {
-    console.error('Error updating challenge via backend:', error);
+    console.error('Error updating challenge internally:', error);
     return NextResponse.json<ApiResponse>({
       success: false,
       error: parseErrorMessage(error)

--- a/src/lib/ai/agents.ts
+++ b/src/lib/ai/agents.ts
@@ -1,0 +1,115 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { AiAgentRecord, AiModelConfig } from "@/types";
+import { fetchModelConfigById } from "./models";
+
+interface AiAgentRow {
+  id: string;
+  slug: string;
+  name: string;
+  description?: string | null;
+  model_config_id?: string | null;
+  fallback_model_config_id?: string | null;
+  system_prompt: string;
+  user_prompt: string;
+  available_variables?: string[] | null;
+  metadata?: Record<string, unknown> | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+function mapAgentRow(row: AiAgentRow): AiAgentRecord {
+  return {
+    id: row.id,
+    slug: row.slug,
+    name: row.name,
+    description: row.description ?? null,
+    modelConfigId: row.model_config_id ?? null,
+    fallbackModelConfigId: row.fallback_model_config_id ?? null,
+    systemPrompt: row.system_prompt,
+    userPrompt: row.user_prompt,
+    availableVariables: row.available_variables ?? [],
+    metadata: row.metadata ?? null,
+    createdAt: row.created_at ?? undefined,
+    updatedAt: row.updated_at ?? undefined,
+  };
+}
+
+export async function fetchAgentBySlug(
+  supabase: SupabaseClient,
+  slug: string,
+  options: { includeModels?: boolean } = {},
+): Promise<AiAgentRecord | null> {
+  const { data, error } = await supabase
+    .from("ai_agents")
+    .select("*")
+    .eq("slug", slug)
+    .maybeSingle<AiAgentRow>();
+
+  if (error) {
+    throw error;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  const agent = mapAgentRow(data);
+
+  if (options.includeModels) {
+    const [modelConfig, fallbackConfig] = await Promise.all([
+      agent.modelConfigId ? fetchModelConfigById(supabase, agent.modelConfigId) : Promise.resolve(null),
+      agent.fallbackModelConfigId ? fetchModelConfigById(supabase, agent.fallbackModelConfigId) : Promise.resolve(null),
+    ]);
+
+    return {
+      ...agent,
+      modelConfig,
+      fallbackModelConfig: fallbackConfig,
+    } satisfies AiAgentRecord & {
+      modelConfig?: AiModelConfig | null;
+      fallbackModelConfig?: AiModelConfig | null;
+    };
+  }
+
+  return agent;
+}
+
+export async function listAgents(
+  supabase: SupabaseClient,
+  options: { includeModels?: boolean } = {},
+): Promise<AiAgentRecord[]> {
+  const { data, error } = await supabase
+    .from("ai_agents")
+    .select("*")
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    throw error;
+  }
+
+  const mapped = (data ?? []).map(mapAgentRow);
+
+  if (!options.includeModels) {
+    return mapped;
+  }
+
+  const enriched = await Promise.all(
+    mapped.map(async (agent) => {
+      const [modelConfig, fallbackConfig] = await Promise.all([
+        agent.modelConfigId ? fetchModelConfigById(supabase, agent.modelConfigId) : Promise.resolve(null),
+        agent.fallbackModelConfigId ? fetchModelConfigById(supabase, agent.fallbackModelConfigId) : Promise.resolve(null),
+      ]);
+
+      return {
+        ...agent,
+        modelConfig,
+        fallbackModelConfig: fallbackConfig,
+      } satisfies AiAgentRecord & {
+        modelConfig?: AiModelConfig | null;
+        fallbackModelConfig?: AiModelConfig | null;
+      };
+    })
+  );
+
+  return enriched;
+}

--- a/src/lib/ai/constants.ts
+++ b/src/lib/ai/constants.ts
@@ -1,0 +1,67 @@
+import type { PromptVariableDefinition } from "@/types";
+
+export const PROMPT_VARIABLES: PromptVariableDefinition[] = [
+  {
+    key: "ask_key",
+    label: "Clé ASK",
+    description: "Identifiant unique de la session ASK en cours.",
+    example: "ask-2024-onboarding",
+  },
+  {
+    key: "ask_question",
+    label: "Question de l'ASK",
+    description: "Texte principal de la question posée aux participants.",
+  },
+  {
+    key: "ask_description",
+    label: "Description de l'ASK",
+    description: "Contexte additionnel associé à la session ASK.",
+  },
+  {
+    key: "system_prompt_project",
+    label: "System Prompt Projet",
+    description: "Prompt spécifique au projet, défini dans la configuration du projet.",
+  },
+  {
+    key: "system_prompt_challenge",
+    label: "System Prompt Challenge",
+    description: "Prompt spécifique au challenge rattaché à l'ASK.",
+  },
+  {
+    key: "system_prompt_ask",
+    label: "System Prompt ASK",
+    description: "Prompt spécifique à la session ASK en cours.",
+  },
+  {
+    key: "message_history",
+    label: "Historique des messages",
+    description: "Historique complet des échanges au format texte prêt à être injecté dans le modèle.",
+  },
+  {
+    key: "latest_user_message",
+    label: "Dernier message utilisateur",
+    description: "Contenu du dernier message envoyé par l'utilisateur ayant déclenché l'appel à l'IA.",
+  },
+  {
+    key: "latest_ai_response",
+    label: "Dernière réponse IA",
+    description: "Contenu généré par l'agent IA lors du dernier appel.",
+  },
+  {
+    key: "participant_name",
+    label: "Nom du participant",
+    description: "Nom affiché du participant qui vient d'envoyer le message.",
+  },
+  {
+    key: "participants",
+    label: "Liste des participants",
+    description: "Participants connus de la session, sérialisés au format lisible.",
+  },
+  {
+    key: "insights_context",
+    label: "Résumé des insights",
+    description: "Résumé concis des insights déjà détectés pour la session.",
+  },
+];
+
+export const DEFAULT_MAX_OUTPUT_TOKENS = 1024;

--- a/src/lib/ai/index.ts
+++ b/src/lib/ai/index.ts
@@ -1,0 +1,7 @@
+export * from "./constants";
+export * from "./models";
+export * from "./agents";
+export * from "./logs";
+export * from "./providers";
+export * from "./service";
+export * from "./templates";

--- a/src/lib/ai/logs.ts
+++ b/src/lib/ai/logs.ts
@@ -1,0 +1,141 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { AiAgentInteractionStatus, AiAgentLog } from "@/types";
+
+interface AiAgentLogRow {
+  id: string;
+  agent_id?: string | null;
+  model_config_id?: string | null;
+  ask_session_id?: string | null;
+  message_id?: string | null;
+  interaction_type: string;
+  request_payload: Record<string, unknown>;
+  response_payload?: Record<string, unknown> | null;
+  status: string;
+  error_message?: string | null;
+  latency_ms?: number | null;
+  created_at: string;
+}
+
+function mapLogRow(row: AiAgentLogRow): AiAgentLog {
+  return {
+    id: row.id,
+    agentId: row.agent_id ?? null,
+    modelConfigId: row.model_config_id ?? null,
+    askSessionId: row.ask_session_id ?? null,
+    messageId: row.message_id ?? null,
+    interactionType: row.interaction_type,
+    requestPayload: row.request_payload ?? {},
+    responsePayload: row.response_payload ?? null,
+    status: row.status as AiAgentInteractionStatus,
+    errorMessage: row.error_message ?? null,
+    latencyMs: row.latency_ms ?? null,
+    createdAt: row.created_at,
+  };
+}
+
+export async function createAgentLog(
+  supabase: SupabaseClient,
+  payload: {
+    agentId?: string | null;
+    modelConfigId?: string | null;
+    askSessionId?: string | null;
+    messageId?: string | null;
+    interactionType: string;
+    requestPayload: Record<string, unknown>;
+  }
+): Promise<AiAgentLog> {
+  const { data, error } = await supabase
+    .from("ai_agent_logs")
+    .insert({
+      agent_id: payload.agentId ?? null,
+      model_config_id: payload.modelConfigId ?? null,
+      ask_session_id: payload.askSessionId ?? null,
+      message_id: payload.messageId ?? null,
+      interaction_type: payload.interactionType,
+      request_payload: payload.requestPayload,
+      status: "pending",
+    })
+    .select("*")
+    .single<AiAgentLogRow>();
+
+  if (error) {
+    throw error;
+  }
+
+  return mapLogRow(data);
+}
+
+export async function markAgentLogProcessing(
+  supabase: SupabaseClient,
+  logId: string,
+  payload: { modelConfigId?: string | null }
+): Promise<void> {
+  const { error } = await supabase
+    .from("ai_agent_logs")
+    .update({
+      status: "processing",
+      model_config_id: payload.modelConfigId ?? null,
+    })
+    .eq("id", logId);
+
+  if (error) {
+    throw error;
+  }
+}
+
+export async function completeAgentLog(
+  supabase: SupabaseClient,
+  logId: string,
+  payload: {
+    responsePayload: Record<string, unknown>;
+    latencyMs?: number;
+  }
+): Promise<void> {
+  const { error } = await supabase
+    .from("ai_agent_logs")
+    .update({
+      status: "completed",
+      response_payload: payload.responsePayload,
+      latency_ms: payload.latencyMs ?? null,
+    })
+    .eq("id", logId);
+
+  if (error) {
+    throw error;
+  }
+}
+
+export async function failAgentLog(
+  supabase: SupabaseClient,
+  logId: string,
+  errorMessage: string,
+): Promise<void> {
+  const { error } = await supabase
+    .from("ai_agent_logs")
+    .update({
+      status: "failed",
+      error_message: errorMessage,
+    })
+    .eq("id", logId);
+
+  if (error) {
+    throw error;
+  }
+}
+
+export async function listAgentLogs(
+  supabase: SupabaseClient,
+  options: { limit?: number }
+): Promise<AiAgentLog[]> {
+  const { data, error } = await supabase
+    .from("ai_agent_logs")
+    .select("*")
+    .order("created_at", { ascending: false })
+    .limit(options.limit ?? 100);
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map(mapLogRow);
+}

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -1,0 +1,83 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { AiModelConfig } from "@/types";
+
+interface AiModelConfigRow {
+  id: string;
+  code: string;
+  name: string;
+  provider: string;
+  model: string;
+  base_url?: string | null;
+  api_key_env_var: string;
+  additional_headers?: Record<string, unknown> | null;
+  is_default?: boolean | null;
+  is_fallback?: boolean | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+function mapModelRow(row: AiModelConfigRow): AiModelConfig {
+  return {
+    id: row.id,
+    code: row.code,
+    name: row.name,
+    provider: row.provider as AiModelConfig["provider"],
+    model: row.model,
+    baseUrl: row.base_url ?? null,
+    apiKeyEnvVar: row.api_key_env_var,
+    additionalHeaders: row.additional_headers ?? null,
+    isDefault: Boolean(row.is_default),
+    isFallback: Boolean(row.is_fallback),
+    createdAt: row.created_at ?? undefined,
+    updatedAt: row.updated_at ?? undefined,
+  };
+}
+
+export async function fetchModelConfigById(
+  supabase: SupabaseClient,
+  id: string,
+): Promise<AiModelConfig | null> {
+  const { data, error } = await supabase
+    .from("ai_model_configs")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle<AiModelConfigRow>();
+
+  if (error) {
+    throw error;
+  }
+
+  return data ? mapModelRow(data) : null;
+}
+
+export async function fetchModelConfigByCode(
+  supabase: SupabaseClient,
+  code: string,
+): Promise<AiModelConfig | null> {
+  const { data, error } = await supabase
+    .from("ai_model_configs")
+    .select("*")
+    .eq("code", code)
+    .maybeSingle<AiModelConfigRow>();
+
+  if (error) {
+    throw error;
+  }
+
+  return data ? mapModelRow(data) : null;
+}
+
+export async function listModelConfigs(
+  supabase: SupabaseClient,
+): Promise<AiModelConfig[]> {
+  const { data, error } = await supabase
+    .from("ai_model_configs")
+    .select("*")
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map(mapModelRow);
+}

--- a/src/lib/ai/providers.ts
+++ b/src/lib/ai/providers.ts
@@ -1,0 +1,253 @@
+import { DEFAULT_MAX_OUTPUT_TOKENS } from "./constants";
+import type { AiModelConfig } from "@/types";
+
+export interface AiProviderRequest {
+  systemPrompt: string;
+  userPrompt: string;
+  maxOutputTokens?: number;
+  temperature?: number;
+}
+
+export interface AiProviderResponse {
+  content: string;
+  raw: Record<string, unknown>;
+}
+
+export class AiProviderError extends Error {
+  constructor(message: string, readonly cause?: unknown) {
+    super(message);
+    this.name = "AiProviderError";
+  }
+}
+
+function resolveApiKey(config: AiModelConfig): string {
+  const key = process.env[config.apiKeyEnvVar];
+  if (!key) {
+    throw new AiProviderError(
+      `Missing API key for model ${config.code}. Define environment variable ${config.apiKeyEnvVar}.`
+    );
+  }
+  return key;
+}
+
+function normaliseBaseUrl(config: AiModelConfig, fallback: string): string {
+  if (config.baseUrl) {
+    return config.baseUrl.replace(/\/$/, "");
+  }
+  return fallback;
+}
+
+async function callAnthropic(
+  config: AiModelConfig,
+  request: AiProviderRequest,
+  abortSignal?: AbortSignal,
+): Promise<AiProviderResponse> {
+  const apiKey = resolveApiKey(config);
+  const baseUrl = normaliseBaseUrl(config, "https://api.anthropic.com/v1");
+  const url = `${baseUrl}/messages`;
+
+  const body = {
+    model: config.model,
+    max_output_tokens: request.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
+    system: request.systemPrompt,
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: request.userPrompt,
+          },
+        ],
+      },
+    ],
+  } satisfies Record<string, unknown>;
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "x-api-key": apiKey,
+    "anthropic-version": "2023-06-01",
+  };
+
+  if (config.additionalHeaders) {
+    for (const [key, value] of Object.entries(config.additionalHeaders)) {
+      if (typeof value === "string") {
+        headers[key] = value;
+      }
+    }
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+    signal: abortSignal,
+  });
+
+  const raw = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    throw new AiProviderError(
+      `Anthropic API error (${response.status}): ${raw?.error?.message ?? response.statusText}`,
+      raw,
+    );
+  }
+
+  const contentBlocks = Array.isArray((raw as any)?.content) ? (raw as any).content : [];
+  const text = contentBlocks
+    .map((block: any) => {
+      if (!block) return "";
+      if (typeof block === "string") return block;
+      if (typeof block.text === "string") return block.text;
+      if (Array.isArray(block.content)) {
+        return block.content
+          .map((inner: any) => (typeof inner?.text === "string" ? inner.text : ""))
+          .join("");
+      }
+      return "";
+    })
+    .join("")
+    .trim();
+
+  return {
+    content: text,
+    raw: raw as Record<string, unknown>,
+  };
+}
+
+async function callMistral(
+  config: AiModelConfig,
+  request: AiProviderRequest,
+  abortSignal?: AbortSignal,
+): Promise<AiProviderResponse> {
+  const apiKey = resolveApiKey(config);
+  const baseUrl = normaliseBaseUrl(config, "https://api.mistral.ai/v1");
+  const url = `${baseUrl}/chat/completions`;
+
+  const body = {
+    model: config.model,
+    temperature: request.temperature ?? 0.2,
+    messages: [
+      { role: "system", content: request.systemPrompt },
+      { role: "user", content: request.userPrompt },
+    ],
+    max_tokens: request.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
+  } satisfies Record<string, unknown>;
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${apiKey}`,
+  };
+
+  if (config.additionalHeaders) {
+    for (const [key, value] of Object.entries(config.additionalHeaders)) {
+      if (typeof value === "string") {
+        headers[key] = value;
+      }
+    }
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+    signal: abortSignal,
+  });
+
+  const raw = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    throw new AiProviderError(
+      `Mistral API error (${response.status}): ${raw?.error?.message ?? response.statusText}`,
+      raw,
+    );
+  }
+
+  const choices = Array.isArray((raw as any)?.choices) ? (raw as any).choices : [];
+  const text = choices
+    .map((choice: any) => choice?.message?.content ?? "")
+    .join("\n")
+    .trim();
+
+  return {
+    content: text,
+    raw: raw as Record<string, unknown>,
+  };
+}
+
+async function callOpenAiCompatible(
+  config: AiModelConfig,
+  request: AiProviderRequest,
+  abortSignal?: AbortSignal,
+): Promise<AiProviderResponse> {
+  const apiKey = resolveApiKey(config);
+  const baseUrl = normaliseBaseUrl(config, "https://api.openai.com/v1");
+  const url = `${baseUrl}/chat/completions`;
+
+  const body = {
+    model: config.model,
+    messages: [
+      { role: "system", content: request.systemPrompt },
+      { role: "user", content: request.userPrompt },
+    ],
+    max_tokens: request.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
+  } satisfies Record<string, unknown>;
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${apiKey}`,
+  };
+
+  if (config.additionalHeaders) {
+    for (const [key, value] of Object.entries(config.additionalHeaders)) {
+      if (typeof value === "string") {
+        headers[key] = value;
+      }
+    }
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+    signal: abortSignal,
+  });
+
+  const raw = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    throw new AiProviderError(
+      `OpenAI compatible API error (${response.status}): ${raw?.error?.message ?? response.statusText}`,
+      raw,
+    );
+  }
+
+  const choices = Array.isArray((raw as any)?.choices) ? (raw as any).choices : [];
+  const text = choices
+    .map((choice: any) => choice?.message?.content ?? "")
+    .join("\n")
+    .trim();
+
+  return {
+    content: text,
+    raw: raw as Record<string, unknown>,
+  };
+}
+
+export async function callModelProvider(
+  config: AiModelConfig,
+  request: AiProviderRequest,
+  abortSignal?: AbortSignal,
+): Promise<AiProviderResponse> {
+  switch (config.provider) {
+    case "anthropic":
+      return callAnthropic(config, request, abortSignal);
+    case "mistral":
+      return callMistral(config, request, abortSignal);
+    case "openai":
+    case "custom":
+      return callOpenAiCompatible(config, request, abortSignal);
+    default:
+      throw new AiProviderError(`Unsupported AI provider: ${config.provider}`);
+  }
+}

--- a/src/lib/ai/service.ts
+++ b/src/lib/ai/service.ts
@@ -1,0 +1,156 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { fetchAgentBySlug } from "./agents";
+import { renderTemplate } from "./templates";
+import { callModelProvider, AiProviderError, type AiProviderResponse } from "./providers";
+import { createAgentLog, markAgentLogProcessing, completeAgentLog, failAgentLog } from "./logs";
+import { DEFAULT_MAX_OUTPUT_TOKENS } from "./constants";
+import type { AiAgentRecord, AiModelConfig } from "@/types";
+
+export interface ExecuteAgentOptions {
+  supabase: SupabaseClient;
+  agentSlug: string;
+  askSessionId?: string | null;
+  messageId?: string | null;
+  interactionType: string;
+  variables: Record<string, string | null | undefined>;
+  maxOutputTokens?: number;
+  temperature?: number;
+}
+
+export interface AgentExecutionResult {
+  content: string;
+  raw: Record<string, unknown>;
+  logId: string;
+  agent: AiAgentRecord;
+  modelConfig: AiModelConfig;
+}
+
+function delay(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function buildRequestPayload(agent: AiAgentRecord, prompts: { system: string; user: string }) {
+  return {
+    agentSlug: agent.slug,
+    modelConfigId: agent.modelConfigId,
+    fallbackModelConfigId: agent.fallbackModelConfigId,
+    systemPrompt: prompts.system,
+    userPrompt: prompts.user,
+  } satisfies Record<string, unknown>;
+}
+
+function pickModelConfigs(agent: AiAgentRecord): AiModelConfig[] {
+  const configs: AiModelConfig[] = [];
+  if (agent.modelConfig) {
+    configs.push(agent.modelConfig);
+  }
+  if (agent.fallbackModelConfig) {
+    const isDuplicate = configs.some(config => config.id === agent.fallbackModelConfig!.id);
+    if (!isDuplicate) {
+      configs.push(agent.fallbackModelConfig);
+    }
+  }
+  return configs;
+}
+
+async function ensureAgentHasModel(agent: AiAgentRecord): Promise<AiAgentRecord> {
+  if (agent.modelConfigId && !agent.modelConfig) {
+    throw new Error(`Agent ${agent.slug} is missing its primary model configuration`);
+  }
+  if (agent.fallbackModelConfigId && !agent.fallbackModelConfig) {
+    throw new Error(`Agent ${agent.slug} is missing its fallback model configuration`);
+  }
+  if (!agent.modelConfig) {
+    throw new Error(`Agent ${agent.slug} is not linked to any model configuration`);
+  }
+  return agent;
+}
+
+export async function executeAgent(options: ExecuteAgentOptions): Promise<AgentExecutionResult> {
+  const agent = await fetchAgentBySlug(options.supabase, options.agentSlug, { includeModels: true });
+
+  if (!agent) {
+    throw new Error(`Unable to find AI agent with slug "${options.agentSlug}"`);
+  }
+
+  await ensureAgentHasModel(agent);
+
+  const prompts = {
+    system: renderTemplate(agent.systemPrompt, options.variables),
+    user: renderTemplate(agent.userPrompt, options.variables),
+  };
+
+  const log = await createAgentLog(options.supabase, {
+    agentId: agent.id,
+    askSessionId: options.askSessionId ?? null,
+    messageId: options.messageId ?? null,
+    interactionType: options.interactionType,
+    requestPayload: {
+      ...buildRequestPayload(agent, prompts),
+      variables: options.variables,
+    },
+  });
+
+  const configs = pickModelConfigs(agent);
+
+  if (configs.length === 0) {
+    await failAgentLog(options.supabase, log.id, "No model configuration available");
+    throw new Error(`No model configuration available for agent ${agent.slug}`);
+  }
+
+  const maxTokens = options.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS;
+
+  let lastError: unknown = null;
+
+  for (const config of configs) {
+    await markAgentLogProcessing(options.supabase, log.id, { modelConfigId: config.id });
+
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      try {
+        const started = Date.now();
+        const response: AiProviderResponse = await callModelProvider(
+          config,
+          {
+            systemPrompt: prompts.system,
+            userPrompt: prompts.user,
+            maxOutputTokens: maxTokens,
+            temperature: options.temperature,
+          },
+        );
+        const latency = Date.now() - started;
+
+        await completeAgentLog(options.supabase, log.id, {
+          responsePayload: response.raw,
+          latencyMs: latency,
+        });
+
+        return {
+          content: response.content,
+          raw: response.raw,
+          logId: log.id,
+          agent,
+          modelConfig: config,
+        };
+      } catch (error) {
+        lastError = error;
+        if (attempt < 3) {
+          await delay(3000);
+        }
+      }
+    }
+  }
+
+  const message = lastError instanceof AiProviderError
+    ? lastError.message
+    : lastError instanceof Error
+      ? lastError.message
+      : "Unknown error while executing AI agent";
+
+  await failAgentLog(options.supabase, log.id, message);
+
+  if (lastError instanceof Error) {
+    throw lastError;
+  }
+
+  throw new Error(message);
+}

--- a/src/lib/ai/templates.ts
+++ b/src/lib/ai/templates.ts
@@ -1,0 +1,33 @@
+const VARIABLE_PATTERN = /{{\s*([a-zA-Z0-9_.-]+)\s*}}/g;
+
+export function renderTemplate(
+  template: string,
+  variables: Record<string, string | null | undefined>,
+): string {
+  if (!template) {
+    return "";
+  }
+
+  return template.replace(VARIABLE_PATTERN, (_, key: string) => {
+    const value = variables[key];
+    if (value === null || value === undefined) {
+      return "";
+    }
+    return String(value);
+  });
+}
+
+export function extractTemplateVariables(template: string): string[] {
+  if (!template) {
+    return [];
+  }
+
+  const matches = template.matchAll(VARIABLE_PATTERN);
+  const found = new Set<string>();
+  for (const match of matches) {
+    if (match[1]) {
+      found.add(match[1]);
+    }
+  }
+  return Array.from(found);
+}

--- a/src/lib/ai/templates.ts
+++ b/src/lib/ai/templates.ts
@@ -22,9 +22,11 @@ export function extractTemplateVariables(template: string): string[] {
     return [];
   }
 
-  const matches = template.matchAll(VARIABLE_PATTERN);
   const found = new Set<string>();
-  for (const match of matches) {
+  const iterator = new RegExp(VARIABLE_PATTERN.source, "g");
+
+  let match: RegExpExecArray | null;
+  while ((match = iterator.exec(template)) !== null) {
     if (match[1]) {
       found.add(match[1]);
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -167,6 +167,82 @@ export interface SessionData {
   error: string | null;
 }
 
+// AI agent configuration
+export type AiModelProvider = "anthropic" | "mistral" | "openai" | "custom";
+
+export interface AiModelConfig {
+  id: string;
+  code: string;
+  name: string;
+  provider: AiModelProvider;
+  model: string;
+  baseUrl?: string | null;
+  apiKeyEnvVar: string;
+  additionalHeaders?: Record<string, unknown> | null;
+  isDefault?: boolean;
+  isFallback?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface AiAgentRecord {
+  id: string;
+  slug: string;
+  name: string;
+  description?: string | null;
+  modelConfigId?: string | null;
+  fallbackModelConfigId?: string | null;
+  systemPrompt: string;
+  userPrompt: string;
+  availableVariables: string[];
+  metadata?: Record<string, unknown> | null;
+  createdAt?: string;
+  updatedAt?: string;
+  modelConfig?: AiModelConfig | null;
+  fallbackModelConfig?: AiModelConfig | null;
+}
+
+export type AiAgentInteractionStatus = "pending" | "processing" | "completed" | "failed";
+
+export interface AiAgentLog {
+  id: string;
+  agentId?: string | null;
+  modelConfigId?: string | null;
+  askSessionId?: string | null;
+  messageId?: string | null;
+  interactionType: string;
+  requestPayload: Record<string, unknown>;
+  responsePayload?: Record<string, unknown> | null;
+  status: AiAgentInteractionStatus;
+  errorMessage?: string | null;
+  latencyMs?: number | null;
+  createdAt: string;
+}
+
+export type AiInsightJobStatus = "pending" | "processing" | "completed" | "failed";
+
+export interface AiInsightJob {
+  id: string;
+  askSessionId: string;
+  messageId?: string | null;
+  agentId?: string | null;
+  modelConfigId?: string | null;
+  status: AiInsightJobStatus;
+  attempts: number;
+  lastError?: string | null;
+  startedAt?: string | null;
+  finishedAt?: string | null;
+  createdAt: string;
+  updatedAt?: string | null;
+}
+
+export interface PromptVariableDefinition {
+  key: string;
+  label: string;
+  description: string;
+  example?: string;
+}
+
 // Types for component props
 export interface ChatComponentProps {
   askKey: string;


### PR DESCRIPTION
## Summary
- add a new migration that removes the legacy n8n history table, introduces ai_model_configs, ai_agents, ai_agent_logs, ai_insight_jobs, and stores system prompts on projects/challenges/asks
- refactor the ASK response API to use the new executeAgent helper with retries, logging, and sequential insight detection jobs instead of calling an external webhook
- expose admin endpoints and interfaces to manage agents, models, and AI logs while documenting the new architecture and environment variables

## Testing
- `npm run lint` *(fails: command enters interactive setup and cannot complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e01f6bff44832abec4d42cf7920193