### PR TITLE
Fix Anthropc API max_tokens parameter name

### DIFF
--- a/src/lib/ai/providers.ts
+++ b/src/lib/ai/providers.ts
@@ -57,7 +57,7 @@ async function callAnthropic(
 
   const body: Record<string, unknown> = {
     model: config.model,
-    max_output_tokens: request.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
+    max_tokens: request.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
     system: request.systemPrompt,
     messages: [
       {


### PR DESCRIPTION
## Summary
- correct the Anthropc messages payload to send max_tokens instead of the invalid max_output_tokens field

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0c2f578ac832a9a9ed0967e136488