### PR TITLE
Allow manual ASK creation without challenge context

### DIFF
--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -1153,14 +1153,20 @@ export function AdminDashboard({ initialProjectId = null, mode = "default" }: Ad
       const { askKey: _askKey, ...updatePayload } = payload;
       await updateAsk(editingAskId, updatePayload);
     } else {
-      if (!selectedChallenge || !selectedProject) {
+      const projectId = selectedChallenge?.projectId ?? selectedProjectId;
+
+      if (!projectId) {
+        setFeedback({
+          type: "error",
+          message: "Select a project before creating an ASK."
+        });
         return;
       }
 
       await createAsk({
         ...payload,
-        projectId: selectedProject.id,
-        challengeId: selectedChallenge.id
+        projectId,
+        challengeId: selectedChallenge?.id ?? ""
       });
     }
 


### PR DESCRIPTION
## Summary
- allow the admin ASK form to create sessions even when no challenge is selected by falling back to the chosen project
- surface a user-facing error when no project context is available for manual ASK creation

## Testing
- not run (next lint prompts for initial configuration)


------
https://chatgpt.com/codex/tasks/task_e_68e43560ffa0832a9eff7f3cad4cf3a5