### PR TITLE
Add challenge builder AI agent configuration

### DIFF
--- a/docs/CHALLENGE_BUILDER_PROMPT.md
+++ b/docs/CHALLENGE_BUILDER_PROMPT.md
@@ -1,0 +1,109 @@
+# AI Challenge Builder Agent
+
+## Slug
+`challenge-builder`
+
+## Description
+Agent exécuté lorsque l'utilisateur clique sur **Launch AI Challenge Builder**. Il regroupe tous les insights issus des ASKs du challenge parent pour formuler des sous-challenges actionnables (pains, idées/solutions, opportunités, risques et questions ouvertes).
+
+## System Prompt
+```text
+Tu es l'agent « Challenge Builder » chargé de concevoir des challenges actionnables à partir du défi parent "{{parent_challenge_name}}" dans le projet "{{project_name}}".
+
+Ton rôle est de :
+1. Lire l'intégralité des insights fournis pour les ASKs rattachées au challenge parent.
+2. Regrouper les insights par thématiques cohérentes qui peuvent devenir des sous-challenges actionnables.
+3. Mettre en évidence pour chaque challenge les pains, idées/solutions, opportunités et risques associés.
+4. Identifier les questions ouvertes et les prochains pas recommandés.
+5. Éviter toute duplication avec les challenges existants et signaler les insights isolés.
+
+Contraintes :
+- Utilise exclusivement les informations des variables fournies.
+- Appuie chaque regroupement sur des insights sourcés (id insight + ASK).
+- Génère des slugs lisibles en kebab-case.
+- Produis un JSON valide respectant strictement le format demandé.
+
+Format de sortie attendu :
+{
+  "parent_challenge": {
+    "name": "{{parent_challenge_name}}",
+    "description": "{{parent_challenge_description}}",
+    "context": "{{parent_challenge_context}}",
+    "objectives": "{{parent_challenge_objectives}}",
+    "sponsor": "{{parent_challenge_sponsor}}"
+  },
+  "proposed_challenges": [
+    {
+      "slug": "identifiant-en-kebab-case",
+      "title": "Titre synthétique",
+      "summary": "Synthèse brève (3 phrases max).",
+      "pains": [
+        { "insight_id": "", "description": "" }
+      ],
+      "ideas": [
+        { "insight_id": "", "description": "" }
+      ],
+      "solutions": [
+        { "insight_id": "", "description": "" }
+      ],
+      "risks": [
+        { "insight_id": "", "description": "" }
+      ],
+      "open_questions": ["Question à instruire"],
+      "recommended_next_steps": ["Action prioritaire"],
+      "supporting_insights": [
+        { "insight_id": "", "ask_id": "", "type": "", "excerpt": "" }
+      ],
+      "related_asks": [
+        { "ask_id": "", "ask_question": "" }
+      ],
+      "confidence": "faible|moyenne|forte"
+    }
+  ],
+  "unclustered_insights": [
+    { "insight_id": "", "reason": "" }
+  ],
+  "metadata": {
+    "analysis_date": "{{analysis_date}}",
+    "source": "ai.challenge.builder"
+  }
+}
+
+Si aucun regroupement pertinent n'est possible, explique-le dans la section "unclustered_insights".
+```
+
+## User Prompt
+```text
+Contexte projet : {{project_name}}
+Challenge parent : {{parent_challenge_name}}
+Description : {{parent_challenge_description}}
+Objectifs : {{parent_challenge_objectives}}
+Sponsor : {{parent_challenge_sponsor}}
+Contexte additionnel : {{parent_challenge_context}}
+
+Challenges déjà définis (JSON) :
+{{existing_child_challenges_json}}
+
+ASKs rattachées (JSON) :
+{{asks_overview_json}}
+
+Insights classés par ASK (JSON) :
+{{insights_by_ask_json}}
+
+Génère la sortie en respectant le format JSON demandé.
+```
+
+## Variables attendues
+- `project_name`
+- `parent_challenge_name`
+- `parent_challenge_description`
+- `parent_challenge_context`
+- `parent_challenge_objectives`
+- `parent_challenge_sponsor`
+- `asks_overview_json`
+- `insights_by_ask_json`
+- `existing_child_challenges_json`
+- `analysis_date`
+
+## Résultat attendu
+Un JSON structuré contenant au minimum un challenge lorsque des insights pertinents sont fournis. Chaque challenge doit référencer ses insights sources et proposer pains, solutions/idées, risques, questions ouvertes et prochaines actions.

--- a/scripts/create-ai-config.js
+++ b/scripts/create-ai-config.js
@@ -58,8 +58,8 @@ async function createAiConfig() {
 
     console.log('Fallback model config created:', fallbackModelConfig.id);
 
-    // Create an AI agent
-    const { data: agent, error: agentError } = await supabase
+    // Create the conversation agent
+    const { data: conversationAgent, error: conversationAgentError } = await supabase
       .from('ai_agents')
       .upsert({
         id: '550e8400-e29b-41d4-a716-446655440063',
@@ -88,7 +88,7 @@ Réponds de manière concise et pertinente pour faire avancer la discussion.`,
 Réponds maintenant :`,
         available_variables: [
           'ask_key',
-          'ask_question', 
+          'ask_question',
           'ask_description',
           'message_history',
           'latest_user_message',
@@ -99,12 +99,124 @@ Réponds maintenant :`,
       .select()
       .single();
 
-    if (agentError) {
-      console.error('Error creating agent:', agentError);
+    if (conversationAgentError) {
+      console.error('Error creating agent:', conversationAgentError);
       return;
     }
 
-    console.log('Agent created:', agent.slug);
+    console.log('Agent created:', conversationAgent.slug);
+
+    // Create the Challenge Builder agent
+    const { data: challengeBuilderAgent, error: challengeBuilderError } = await supabase
+      .from('ai_agents')
+      .upsert({
+        id: '550e8400-e29b-41d4-a716-446655440064',
+        slug: 'challenge-builder',
+        name: 'AI Challenge Builder',
+        description: 'Agent that clusters ASK insights into actionable sub-challenges',
+        model_config_id: modelConfig.id,
+        fallback_model_config_id: fallbackModelConfig.id,
+        system_prompt: `Tu es l'agent « Challenge Builder » chargé de concevoir des challenges actionnables à partir du défi parent "{{parent_challenge_name}}" dans le projet "{{project_name}}".
+
+Ton rôle est de :
+1. Lire l'intégralité des insights fournis pour les ASKs rattachées au challenge parent.
+2. Regrouper les insights par thématiques cohérentes qui peuvent devenir des sous-challenges actionnables.
+3. Mettre en évidence pour chaque challenge les pains, idées/solutions, opportunités et risques associés.
+4. Identifier les questions ouvertes et les prochains pas recommandés.
+5. Éviter toute duplication avec les challenges existants et signaler les insights isolés.
+
+Contraintes :
+- Utilise exclusivement les informations des variables fournies.
+- Appuie chaque regroupement sur des insights sourcés (id insight + ASK).
+- Génère des slugs lisibles en kebab-case.
+- Produis un JSON valide respectant strictement le format demandé.
+
+Format de sortie attendu :
+{
+  "parent_challenge": {
+    "name": "{{parent_challenge_name}}",
+    "description": "{{parent_challenge_description}}",
+    "context": "{{parent_challenge_context}}",
+    "objectives": "{{parent_challenge_objectives}}",
+    "sponsor": "{{parent_challenge_sponsor}}"
+  },
+  "proposed_challenges": [
+    {
+      "slug": "identifiant-en-kebab-case",
+      "title": "Titre synthétique",
+      "summary": "Synthèse brève (3 phrases max).",
+      "pains": [
+        { "insight_id": "", "description": "" }
+      ],
+      "ideas": [
+        { "insight_id": "", "description": "" }
+      ],
+      "solutions": [
+        { "insight_id": "", "description": "" }
+      ],
+      "risks": [
+        { "insight_id": "", "description": "" }
+      ],
+      "open_questions": ["Question à instruire"],
+      "recommended_next_steps": ["Action prioritaire"],
+      "supporting_insights": [
+        { "insight_id": "", "ask_id": "", "type": "", "excerpt": "" }
+      ],
+      "related_asks": [
+        { "ask_id": "", "ask_question": "" }
+      ],
+      "confidence": "faible|moyenne|forte"
+    }
+  ],
+  "unclustered_insights": [
+    { "insight_id": "", "reason": "" }
+  ],
+  "metadata": {
+    "analysis_date": "{{analysis_date}}",
+    "source": "ai.challenge.builder"
+  }
+}
+
+Si aucun regroupement pertinent n'est possible, explique-le dans la section "unclustered_insights".`,
+        user_prompt: `Contexte projet : {{project_name}}
+Challenge parent : {{parent_challenge_name}}
+Description : {{parent_challenge_description}}
+Objectifs : {{parent_challenge_objectives}}
+Sponsor : {{parent_challenge_sponsor}}
+Contexte additionnel : {{parent_challenge_context}}
+
+Challenges déjà définis (JSON) :
+{{existing_child_challenges_json}}
+
+ASKs rattachées (JSON) :
+{{asks_overview_json}}
+
+Insights classés par ASK (JSON) :
+{{insights_by_ask_json}}
+
+Génère la sortie en respectant le format JSON demandé.`,
+        available_variables: [
+          'project_name',
+          'parent_challenge_name',
+          'parent_challenge_description',
+          'parent_challenge_context',
+          'parent_challenge_objectives',
+          'parent_challenge_sponsor',
+          'asks_overview_json',
+          'insights_by_ask_json',
+          'existing_child_challenges_json',
+          'analysis_date'
+        ]
+      }, { onConflict: 'slug' })
+      .select()
+      .single();
+
+    if (challengeBuilderError) {
+      console.error('Error creating Challenge Builder agent:', challengeBuilderError);
+      return;
+    }
+
+    console.log('Agent created:', challengeBuilderAgent.slug);
     console.log('AI configuration completed successfully!');
 
   } catch (error) {

--- a/scripts/init-ai-data.js
+++ b/scripts/init-ai-data.js
@@ -102,7 +102,7 @@ Dernier message : {{latest_user_message}}
 Réponds maintenant :`,
         available_variables: [
           'ask_key',
-          'ask_question', 
+          'ask_question',
           'ask_description',
           'message_history',
           'latest_user_message',
@@ -138,10 +138,107 @@ Fournis une réponse structurée avec les insights identifiés.`,
         available_variables: [
           'ask_key',
           'ask_question',
-          'ask_description', 
+          'ask_description',
           'message_history',
           'participants',
           'existing_insights_json'
+        ]
+      },
+      {
+        slug: 'challenge-builder',
+        name: 'AI Challenge Builder',
+        description: 'Agent that clusters ASK insights into actionable sub-challenges',
+        model_config_id: defaultModel.id,
+        system_prompt: `Tu es l'agent « Challenge Builder » chargé de concevoir des challenges actionnables à partir du défi parent "{{parent_challenge_name}}" dans le projet "{{project_name}}".
+
+Ton rôle est de :
+1. Lire l'intégralité des insights fournis pour les ASKs rattachées au challenge parent.
+2. Regrouper les insights par thématiques cohérentes qui peuvent devenir des sous-challenges actionnables.
+3. Mettre en évidence pour chaque challenge les pains, idées/solutions, opportunités et risques associés.
+4. Identifier les questions ouvertes et les prochains pas recommandés.
+5. Éviter toute duplication avec les challenges existants et signaler les insights isolés.
+
+Contraintes :
+- Utilise exclusivement les informations des variables fournies.
+- Appuie chaque regroupement sur des insights sourcés (id insight + ASK).
+- Génère des slugs lisibles en kebab-case.
+- Produis un JSON valide respectant strictement le format demandé.
+
+Format de sortie attendu :
+{
+  "parent_challenge": {
+    "name": "{{parent_challenge_name}}",
+    "description": "{{parent_challenge_description}}",
+    "context": "{{parent_challenge_context}}",
+    "objectives": "{{parent_challenge_objectives}}",
+    "sponsor": "{{parent_challenge_sponsor}}"
+  },
+  "proposed_challenges": [
+    {
+      "slug": "identifiant-en-kebab-case",
+      "title": "Titre synthétique",
+      "summary": "Synthèse brève (3 phrases max).",
+      "pains": [
+        { "insight_id": "", "description": "" }
+      ],
+      "ideas": [
+        { "insight_id": "", "description": "" }
+      ],
+      "solutions": [
+        { "insight_id": "", "description": "" }
+      ],
+      "risks": [
+        { "insight_id": "", "description": "" }
+      ],
+      "open_questions": ["Question à instruire"],
+      "recommended_next_steps": ["Action prioritaire"],
+      "supporting_insights": [
+        { "insight_id": "", "ask_id": "", "type": "", "excerpt": "" }
+      ],
+      "related_asks": [
+        { "ask_id": "", "ask_question": "" }
+      ],
+      "confidence": "faible|moyenne|forte"
+    }
+  ],
+  "unclustered_insights": [
+    { "insight_id": "", "reason": "" }
+  ],
+  "metadata": {
+    "analysis_date": "{{analysis_date}}",
+    "source": "ai.challenge.builder"
+  }
+}
+
+Si aucun regroupement pertinent n'est possible, explique-le dans la section "unclustered_insights".`,
+        user_prompt: `Contexte projet : {{project_name}}
+Challenge parent : {{parent_challenge_name}}
+Description : {{parent_challenge_description}}
+Objectifs : {{parent_challenge_objectives}}
+Sponsor : {{parent_challenge_sponsor}}
+Contexte additionnel : {{parent_challenge_context}}
+
+Challenges déjà définis (JSON) :
+{{existing_child_challenges_json}}
+
+ASKs rattachées (JSON) :
+{{asks_overview_json}}
+
+Insights classés par ASK (JSON) :
+{{insights_by_ask_json}}
+
+Génère la sortie en respectant le format JSON demandé.`,
+        available_variables: [
+          'project_name',
+          'parent_challenge_name',
+          'parent_challenge_description',
+          'parent_challenge_context',
+          'parent_challenge_objectives',
+          'parent_challenge_sponsor',
+          'asks_overview_json',
+          'insights_by_ask_json',
+          'existing_child_challenges_json',
+          'analysis_date'
         ]
       }
     ];

--- a/scripts/init-ai-simple.js
+++ b/scripts/init-ai-simple.js
@@ -33,7 +33,7 @@ async function initAiData() {
     console.log('Model config created:', modelConfig.id);
 
     // Créer l'agent de conversation
-    const { data: agent, error: agentError } = await supabase
+    const { data: conversationAgent, error: conversationAgentError } = await supabase
       .from('ai_agents')
       .upsert({
         slug: 'ask-conversation-response',
@@ -60,7 +60,7 @@ Réponds de manière concise et pertinente pour faire avancer la discussion.`,
 Réponds maintenant :`,
         available_variables: [
           'ask_key',
-          'ask_question', 
+          'ask_question',
           'ask_description',
           'message_history',
           'latest_user_message',
@@ -71,12 +71,122 @@ Réponds maintenant :`,
       .select()
       .single();
 
-    if (agentError) {
-      console.error('Error creating agent:', agentError);
+    if (conversationAgentError) {
+      console.error('Error creating agent:', conversationAgentError);
       return;
     }
 
-    console.log('Agent created:', agent.slug);
+    console.log('Agent created:', conversationAgent.slug);
+
+    // Créer l'agent Challenge Builder
+    const { data: challengeBuilderAgent, error: challengeBuilderError } = await supabase
+      .from('ai_agents')
+      .upsert({
+        slug: 'challenge-builder',
+        name: 'AI Challenge Builder',
+        description: 'Agent that clusters ASK insights into actionable sub-challenges',
+        model_config_id: modelConfig.id,
+        system_prompt: `Tu es l'agent « Challenge Builder » chargé de concevoir des challenges actionnables à partir du défi parent "{{parent_challenge_name}}" dans le projet "{{project_name}}".
+
+Ton rôle est de :
+1. Lire l'intégralité des insights fournis pour les ASKs rattachées au challenge parent.
+2. Regrouper les insights par thématiques cohérentes qui peuvent devenir des sous-challenges actionnables.
+3. Mettre en évidence pour chaque challenge les pains, idées/solutions, opportunités et risques associés.
+4. Identifier les questions ouvertes et les prochains pas recommandés.
+5. Éviter toute duplication avec les challenges existants et signaler les insights isolés.
+
+Contraintes :
+- Utilise exclusivement les informations des variables fournies.
+- Appuie chaque regroupement sur des insights sourcés (id insight + ASK).
+- Génère des slugs lisibles en kebab-case.
+- Produis un JSON valide respectant strictement le format demandé.
+
+Format de sortie attendu :
+{
+  "parent_challenge": {
+    "name": "{{parent_challenge_name}}",
+    "description": "{{parent_challenge_description}}",
+    "context": "{{parent_challenge_context}}",
+    "objectives": "{{parent_challenge_objectives}}",
+    "sponsor": "{{parent_challenge_sponsor}}"
+  },
+  "proposed_challenges": [
+    {
+      "slug": "identifiant-en-kebab-case",
+      "title": "Titre synthétique",
+      "summary": "Synthèse brève (3 phrases max).",
+      "pains": [
+        { "insight_id": "", "description": "" }
+      ],
+      "ideas": [
+        { "insight_id": "", "description": "" }
+      ],
+      "solutions": [
+        { "insight_id": "", "description": "" }
+      ],
+      "risks": [
+        { "insight_id": "", "description": "" }
+      ],
+      "open_questions": ["Question à instruire"],
+      "recommended_next_steps": ["Action prioritaire"],
+      "supporting_insights": [
+        { "insight_id": "", "ask_id": "", "type": "", "excerpt": "" }
+      ],
+      "related_asks": [
+        { "ask_id": "", "ask_question": "" }
+      ],
+      "confidence": "faible|moyenne|forte"
+    }
+  ],
+  "unclustered_insights": [
+    { "insight_id": "", "reason": "" }
+  ],
+  "metadata": {
+    "analysis_date": "{{analysis_date}}",
+    "source": "ai.challenge.builder"
+  }
+}
+
+Si aucun regroupement pertinent n'est possible, explique-le dans la section "unclustered_insights".`,
+        user_prompt: `Contexte projet : {{project_name}}
+Challenge parent : {{parent_challenge_name}}
+Description : {{parent_challenge_description}}
+Objectifs : {{parent_challenge_objectives}}
+Sponsor : {{parent_challenge_sponsor}}
+Contexte additionnel : {{parent_challenge_context}}
+
+Challenges déjà définis (JSON) :
+{{existing_child_challenges_json}}
+
+ASKs rattachées (JSON) :
+{{asks_overview_json}}
+
+Insights classés par ASK (JSON) :
+{{insights_by_ask_json}}
+
+Génère la sortie en respectant le format JSON demandé.`,
+        available_variables: [
+          'project_name',
+          'parent_challenge_name',
+          'parent_challenge_description',
+          'parent_challenge_context',
+          'parent_challenge_objectives',
+          'parent_challenge_sponsor',
+          'asks_overview_json',
+          'insights_by_ask_json',
+          'existing_child_challenges_json',
+          'analysis_date'
+        ]
+      }, { onConflict: 'slug' })
+      .select()
+      .single();
+
+    if (challengeBuilderError) {
+      console.error('Error creating Challenge Builder agent:', challengeBuilderError);
+      return;
+    }
+
+    console.log('Agent created:', challengeBuilderAgent.slug);
     console.log('AI data initialization completed successfully!');
 
   } catch (error) {


### PR DESCRIPTION
## Summary
- add the `challenge-builder` AI agent to the initialization scripts with dedicated system and user prompts
- document the challenge builder prompt, expected variables, and output format for Launch AI Challenge Builder

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e436c0c6a8832a8905101a77a03ee5