### PR TITLE
Add user profile header menu with mock auth provider

### DIFF
--- a/src/app/HomePage.tsx
+++ b/src/app/HomePage.tsx
@@ -16,6 +16,7 @@ import {
   getAudienceDescription,
   getDeliveryModeLabel,
 } from "@/lib/utils";
+import { UserProfileMenu } from "@/components/auth/UserProfileMenu";
 
 /**
  * Main application page with beautiful glassmorphic design
@@ -779,8 +780,8 @@ export default function HomePage() {
         animate={{ opacity: 1, y: 0 }}
         className="app-header border-0 sticky top-0 z-50"
       >
-        <div className="container mx-auto px-4 sm:px-6 py-3 space-y-3 sm:space-y-4">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="container mx-auto px-4 sm:px-6 py-3 space-y-4">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <motion.div
               className="flex items-center gap-2.5"
               whileHover={{ scale: 1.05 }}
@@ -798,45 +799,47 @@ export default function HomePage() {
                 )}
               </div>
             </motion.div>
-            {askDetails && (
-              <motion.div
-                initial={{ opacity: 0, y: -10 }}
-                animate={{ opacity: 1, y: 0 }}
-                className="w-full rounded-xl border border-white/50 bg-white/80 backdrop-blur px-4 py-4 shadow-sm sm:max-w-[75vw] md:max-w-3xl"
-              >
-                <div className="flex flex-col gap-3">
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                    <div className="space-y-1 sm:pr-4">
-                      <h3 className="font-semibold tracking-tight text-xs sm:text-sm leading-snug text-foreground">
-                        {askDetails.question}
-                      </h3>
-                      {askDetails.description && !isDetailsCollapsed && (
-                        <p className="text-xs sm:text-sm text-muted-foreground leading-relaxed">
-                          {askDetails.description}
-                        </p>
-                      )}
-                    </div>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setIsDetailsCollapsed(prev => !prev)}
-                      className="inline-flex items-center gap-1.5 whitespace-nowrap self-start sm:self-start"
-                      aria-expanded={!isDetailsCollapsed}
-                    >
-                      {isDetailsCollapsed ? (
-                        <>
-                          <ChevronDown className="h-4 w-4" />
-                          Infos
-                        </>
-                      ) : (
-                        <>
-                          <ChevronUp className="h-4 w-4" />
-                          Masquer
-                        </>
-                      )}
-                    </Button>
+            <div className="flex justify-end">
+              <UserProfileMenu />
+            </div>
+          </div>
+          {askDetails && (
+            <motion.div
+              initial={{ opacity: 0, y: -10 }}
+              animate={{ opacity: 1, y: 0 }}
+              className="w-full rounded-xl border border-white/50 bg-white/80 backdrop-blur px-4 py-4 shadow-sm sm:max-w-[75vw] md:max-w-3xl"
+            >
+              <div className="flex flex-col gap-3">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="space-y-1 sm:pr-4">
+                    <h3 className="font-semibold tracking-tight text-xs sm:text-sm leading-snug text-foreground">
+                      {askDetails.question}
+                    </h3>
+                    {askDetails.description && !isDetailsCollapsed && (
+                      <p className="text-xs sm:text-sm text-muted-foreground leading-relaxed">
+                        {askDetails.description}
+                      </p>
+                    )}
                   </div>
-
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setIsDetailsCollapsed(prev => !prev)}
+                    className="inline-flex items-center gap-1.5 whitespace-nowrap self-start sm:self-start"
+                    aria-expanded={!isDetailsCollapsed}
+                  >
+                    {isDetailsCollapsed ? (
+                      <>
+                        <ChevronDown className="h-4 w-4" />
+                        Infos
+                      </>
+                    ) : (
+                      <>
+                        <ChevronUp className="h-4 w-4" />
+                        Masquer
+                      </>
+                    )}
+                  </Button>
                 </div>
 
                 <AnimatePresence initial={false}>
@@ -848,27 +851,27 @@ export default function HomePage() {
                       exit={{ height: 0, opacity: 0 }}
                       className="mt-3 overflow-hidden"
                     >
-                    <div className="grid gap-3 sm:gap-4 text-sm text-muted-foreground sm:grid-cols-3">
-                      <div className="space-y-1.5">
-                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/80">Session</p>
-                        <div className="flex flex-wrap items-center gap-2">
-                          {sessionData.askKey && (
-                            <span className="inline-flex items-center rounded-full bg-white/80 px-3 py-1 text-xs font-medium text-foreground shadow-sm">
-                              Session:
-                              <span className="font-mono text-foreground ml-1">{sessionData.askKey}</span>
-                            </span>
-                          )}
-                          {sessionData.ask && (
-                            <span className={sessionData.ask.isActive ? 'session-active' : 'session-closed'}>
-                              {sessionData.ask.isActive ? 'Active' : 'Closed'}
-                            </span>
-                          )}
+                      <div className="grid gap-3 sm:gap-4 text-sm text-muted-foreground sm:grid-cols-3">
+                        <div className="space-y-1.5">
+                          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/80">Session</p>
+                          <div className="flex flex-wrap items-center gap-2">
+                            {sessionData.askKey && (
+                              <span className="inline-flex items-center rounded-full bg-white/80 px-3 py-1 text-xs font-medium text-foreground shadow-sm">
+                                Session:
+                                <span className="font-mono text-foreground ml-1">{sessionData.askKey}</span>
+                              </span>
+                            )}
+                            {sessionData.ask && (
+                              <span className={sessionData.ask.isActive ? 'session-active' : 'session-closed'}>
+                                {sessionData.ask.isActive ? 'Active' : 'Closed'}
+                              </span>
+                            )}
+                          </div>
                         </div>
-                      </div>
 
-                      <div className="space-y-1.5">
-                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/80">Statut</p>
-                        <div className="flex flex-wrap items-center gap-2">
+                        <div className="space-y-1.5">
+                          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/80">Statut</p>
+                          <div className="flex flex-wrap items-center gap-2">
                             <span className="inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
                               {statusLabel}
                             </span>
@@ -888,41 +891,41 @@ export default function HomePage() {
                             <p className="font-medium">
                               {getDeliveryModeLabel(askDetails.deliveryMode)}
                             </p>
-                          <p className="text-muted-foreground">
-                            {getAudienceDescription(askDetails.audienceScope, askDetails.responseMode)}
-                          </p>
+                            <p className="text-muted-foreground">
+                              {getAudienceDescription(askDetails.audienceScope, askDetails.responseMode)}
+                            </p>
+                          </div>
                         </div>
-                      </div>
 
-                      <div className="space-y-1.5">
-                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/80">
-                          Participants ({participants.length})
-                        </p>
-                        <div className="flex flex-wrap gap-2">
-                          {participants.length > 0 ? (
-                            participants.map(participant => (
-                              <span
-                                key={participant.id}
-                                className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-xs text-primary"
-                              >
-                                <span className="font-medium text-primary/90">{participant.name}</span>
-                                {participant.isSpokesperson && (
-                                  <span className="text-[10px] uppercase tracking-wide text-primary/70">porte-parole</span>
-                                )}
-                              </span>
-                            ))
-                          ) : (
-                            <span className="text-muted-foreground">Aucun participant pour le moment</span>
-                          )}
+                        <div className="space-y-1.5">
+                          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/80">
+                            Participants ({participants.length})
+                          </p>
+                          <div className="flex flex-wrap gap-2">
+                            {participants.length > 0 ? (
+                              participants.map(participant => (
+                                <span
+                                  key={participant.id}
+                                  className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-xs text-primary"
+                                >
+                                  <span className="font-medium text-primary/90">{participant.name}</span>
+                                  {participant.isSpokesperson && (
+                                    <span className="text-[10px] uppercase tracking-wide text-primary/70">porte-parole</span>
+                                  )}
+                                </span>
+                              ))
+                            ) : (
+                              <span className="text-muted-foreground">Aucun participant pour le moment</span>
+                            )}
+                          </div>
                         </div>
                       </div>
-                    </div>
-                  </motion.div>
-                )}
-              </AnimatePresence>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
             </motion.div>
           )}
-        </div>
         </div>
       </motion.header>
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import { AuthProvider } from "@/components/auth/AuthProvider";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -28,7 +29,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
-        {children}
+        <AuthProvider>{children}</AuthProvider>
       </body>
     </html>
   );

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import React, { createContext, useContext, useMemo, useState, useEffect, useCallback } from "react";
+
+export type AuthUser = {
+  id: string;
+  email: string;
+  fullName: string;
+  avatarUrl?: string | null;
+  role?: string | null;
+};
+
+type AuthStatus = "loading" | "signed-out" | "signed-in";
+
+type AuthContextValue = {
+  status: AuthStatus;
+  user: AuthUser | null;
+  isProcessing: boolean;
+  signIn: () => Promise<void>;
+  signOut: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+/**
+ * Temporary mock authentication provider.
+ * Sets up the context structure that will later be backed by Supabase auth.
+ */
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [status, setStatus] = useState<AuthStatus>("loading");
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  // Simulate reading the session from storage/backend
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setStatus("signed-out");
+    }, 400);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  const signIn = useCallback(async () => {
+    if (isProcessing) return;
+    setIsProcessing(true);
+
+    await new Promise(resolve => setTimeout(resolve, 600));
+
+    setUser({
+      id: "demo-user",
+      email: "demo.user@example.com",
+      fullName: "Demo User",
+      avatarUrl: null,
+      role: "facilitator",
+    });
+    setStatus("signed-in");
+    setIsProcessing(false);
+  }, [isProcessing]);
+
+  const signOut = useCallback(async () => {
+    if (isProcessing) return;
+    setIsProcessing(true);
+
+    await new Promise(resolve => setTimeout(resolve, 300));
+
+    setUser(null);
+    setStatus("signed-out");
+    setIsProcessing(false);
+  }, [isProcessing]);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({ status, user, isProcessing, signIn, signOut }),
+    [status, user, isProcessing, signIn, signOut]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+}

--- a/src/components/auth/UserProfileMenu.tsx
+++ b/src/components/auth/UserProfileMenu.tsx
@@ -6,14 +6,25 @@ import { Loader2, LogIn, LogOut, Settings, UserCircle2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "./AuthProvider";
 
-function getInitials(name: string) {
-  const [first = "", second = ""] = name.trim().split(" ");
-  return (first.charAt(0) + second.charAt(0)).toUpperCase();
+function getInitials(name?: string | null) {
+  if (!name) return "";
+  const parts = name
+    .trim()
+    .split(" ")
+    .filter(Boolean);
+  if (parts.length === 0) return "";
+  const [first, second] = parts;
+  const firstInitial = first?.charAt(0) ?? "";
+  const secondInitial = second?.charAt(0) ?? "";
+  return (firstInitial + secondInitial).toUpperCase();
 }
 
 export function UserProfileMenu() {
   const { status, user, signIn, signOut, isProcessing } = useAuth();
   const isSignedIn = status === "signed-in" && Boolean(user);
+  const fullName = user?.fullName ?? "";
+  const email = user?.email ?? "";
+  const role = user?.role ?? undefined;
 
   return (
     <DropdownMenu.Root>
@@ -25,7 +36,7 @@ export function UserProfileMenu() {
         >
           <div className="relative flex h-9 w-9 items-center justify-center overflow-hidden rounded-full bg-gradient-to-br from-primary to-accent text-white">
             {isSignedIn ? (
-              <span className="text-sm font-semibold">{getInitials(user.fullName)}</span>
+              <span className="text-sm font-semibold">{getInitials(fullName)}</span>
             ) : (
               <UserCircle2 className="h-5 w-5" />
             )}
@@ -35,7 +46,7 @@ export function UserProfileMenu() {
               {isSignedIn ? "Connecté" : status === "loading" ? "Chargement" : "Invité"}
             </span>
             <span className="text-sm font-semibold text-foreground">
-              {isSignedIn ? user.fullName : "Accéder"}
+              {isSignedIn ? fullName : "Accéder"}
             </span>
           </div>
         </Button>
@@ -47,11 +58,11 @@ export function UserProfileMenu() {
         <div className="rounded-xl bg-white/70 p-3 shadow-inner">
           {isSignedIn ? (
             <div className="space-y-1">
-              <p className="text-sm font-semibold text-foreground">{user.fullName}</p>
-              <p className="text-xs text-muted-foreground">{user.email}</p>
-              {user.role && (
+              <p className="text-sm font-semibold text-foreground">{fullName}</p>
+              <p className="text-xs text-muted-foreground">{email}</p>
+              {role && (
                 <span className="inline-flex items-center rounded-full bg-primary/10 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
-                  {user.role}
+                  {role}
                 </span>
               )}
             </div>

--- a/src/components/auth/UserProfileMenu.tsx
+++ b/src/components/auth/UserProfileMenu.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import React from "react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { Loader2, LogIn, LogOut, Settings, UserCircle2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "./AuthProvider";
+
+function getInitials(name: string) {
+  const [first = "", second = ""] = name.trim().split(" ");
+  return (first.charAt(0) + second.charAt(0)).toUpperCase();
+}
+
+export function UserProfileMenu() {
+  const { status, user, signIn, signOut, isProcessing } = useAuth();
+  const isSignedIn = status === "signed-in" && Boolean(user);
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <Button
+          variant="ghost"
+          className="flex items-center gap-3 rounded-full border border-white/40 bg-white/70 px-3 py-1.5 text-sm font-medium text-foreground shadow-sm transition hover:bg-white"
+          disabled={status === "loading"}
+        >
+          <div className="relative flex h-9 w-9 items-center justify-center overflow-hidden rounded-full bg-gradient-to-br from-primary to-accent text-white">
+            {isSignedIn ? (
+              <span className="text-sm font-semibold">{getInitials(user.fullName)}</span>
+            ) : (
+              <UserCircle2 className="h-5 w-5" />
+            )}
+          </div>
+          <div className="flex flex-col items-start leading-tight">
+            <span className="text-xs uppercase tracking-wide text-muted-foreground/80">
+              {isSignedIn ? "Connecté" : status === "loading" ? "Chargement" : "Invité"}
+            </span>
+            <span className="text-sm font-semibold text-foreground">
+              {isSignedIn ? user.fullName : "Accéder"}
+            </span>
+          </div>
+        </Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content className="z-50 mt-2 w-64 rounded-2xl border border-white/60 bg-white/90 p-3 text-sm shadow-xl backdrop-blur">
+        <DropdownMenu.Label className="px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Profil utilisateur
+        </DropdownMenu.Label>
+        <div className="rounded-xl bg-white/70 p-3 shadow-inner">
+          {isSignedIn ? (
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-foreground">{user.fullName}</p>
+              <p className="text-xs text-muted-foreground">{user.email}</p>
+              {user.role && (
+                <span className="inline-flex items-center rounded-full bg-primary/10 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
+                  {user.role}
+                </span>
+              )}
+            </div>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              Connectez-vous pour synchroniser vos défis, conversations et expériences personnalisées.
+            </p>
+          )}
+        </div>
+
+        <DropdownMenu.Separator className="my-3 h-px bg-gradient-to-r from-transparent via-primary/20 to-transparent" />
+
+        {isSignedIn ? (
+          <DropdownMenu.Item
+            className="flex cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-foreground outline-none transition hover:bg-primary/10"
+          >
+            <Settings className="h-4 w-4 text-primary" />
+            Paramètres du compte
+          </DropdownMenu.Item>
+        ) : (
+          <DropdownMenu.Item
+            className="flex cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-foreground outline-none transition hover:bg-primary/10"
+          >
+            <Settings className="h-4 w-4 text-primary" />
+            Préférences invité
+          </DropdownMenu.Item>
+        )}
+
+        <DropdownMenu.Arrow className="fill-white/70" />
+
+        <div className="mt-3 rounded-xl bg-gradient-to-r from-primary/90 to-accent/90 p-3 text-white">
+          {isSignedIn ? (
+            <Button
+              onClick={() => signOut()}
+              variant="ghost"
+              className="flex w-full items-center justify-center gap-2 rounded-full bg-white/10 text-white hover:bg-white/20"
+              disabled={isProcessing}
+            >
+              {isProcessing ? <Loader2 className="h-4 w-4 animate-spin" /> : <LogOut className="h-4 w-4" />}
+              Se déconnecter
+            </Button>
+          ) : (
+            <Button
+              onClick={() => signIn()}
+              className="flex w-full items-center justify-center gap-2 rounded-full bg-white/90 text-primary hover:bg-white"
+              disabled={isProcessing || status === "loading"}
+            >
+              {isProcessing ? <Loader2 className="h-4 w-4 animate-spin" /> : <LogIn className="h-4 w-4" />}
+              Se connecter
+            </Button>
+          )}
+        </div>
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
+  );
+}


### PR DESCRIPTION
## Summary
- add a temporary auth provider context to prepare for future Supabase integration
- introduce a user profile dropdown menu in the main header and adjust layout spacing
- wrap the application layout with the auth provider so the mock user state is available globally

## Testing
- not run (Next.js lint command prompts for interactive setup)

------
https://chatgpt.com/codex/tasks/task_e_68e64ced4454832a9403e07ea777766b